### PR TITLE
Throttle down recoding progress status updates

### DIFF
--- a/bot/camera.py
+++ b/bot/camera.py
@@ -371,9 +371,12 @@ class Camera:
             out = cv2.VideoWriter(video_filepath, fourcc=cv2.VideoWriter_fourcc(*self._fourcc), fps=lapse_fps, frameSize=(width, height))
 
             info_mess.edit_text(text=f"Images recoding")
+            last_update_time = time.time()
             for fnum, filename in enumerate(photos):
-                if fnum % lapse_fps == 0:
+                if time.time() >= last_update_time + 3:
                     info_mess.edit_text(text=f"Images recoded {fnum}/{photo_count}")
+                    last_update_time = time.time()
+
                 out.write(cv2.imread(filename))
 
             info_mess.edit_text(text=f"Repeating last image for {self._last_frame_duration} seconds")

--- a/bot/main.py
+++ b/bot/main.py
@@ -438,7 +438,10 @@ def bot_error_handler(_: object, context: CallbackContext) -> None:
 
 
 def start_bot(bot_token, socks):
-    request_kwargs = {}
+    request_kwargs = {
+        'read_timeout': 15,
+    }
+
     if socks:
         request_kwargs['proxy_url'] = f'socks5://{socks}'
 


### PR DESCRIPTION
Based on https://github.com/nlef/moonraker-telegram-bot/issues/85 and some testing I figured out that Telegram may be blocking updates if they're too quick. This commit changes the throttling mechanism to be more independent from hardware performance and makes it time based. Also - increase the read timeout from default 5 seconds to 15.