### PR TITLE
Update install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -74,7 +74,7 @@ create_virtualenv() {
   mkdir -p "${HOME}"/space
   virtualenv -p /usr/bin/python3 --system-site-packages "${MOONRAKER_BOT_ENV}"
   export TMPDIR=${HOME}/space
-  "${MOONRAKER_BOT_ENV}"/bin/pip install -r "${MOONRAKER_BOT_DIR}"/scripts/requirements.txt
+  "${MOONRAKER_BOT_ENV}"/bin/pip install --no-cache-dir -r "${MOONRAKER_BOT_DIR}"/scripts/requirements.txt
 }
 
 create_service() {


### PR DESCRIPTION
Added option `--no-cache-dir` when installing packages.

When trying to install bot on Debian 11 using KIAUH, the installation completes without errors. 
But at the start of the bot, namely at the moment of importing the Camera.py file, and in it the Pillow module, I get the error `ImportError: cannot import name '_webp' from 'PIL'`
I checked that the system itself does not have the same module, created a virtual environment with and without system module imports, tried reinstalling the Pillow in the environment manually to no avail.
All the time, the cached version of the Pillow was pulled up.

For me, the solution was to disable the cache during installation.

I understand that this will increase installation time and network activity, but maybe it will save someone time, you don’t have to look for a complex solution to a simple problem.