### PR TITLE
Added spaces before power devices emojis'

### DIFF
--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -245,9 +245,9 @@ class Klippy:
     def _get_power_devices_mess(self) -> str:
         message = ''
         if self._light_device and self._light_device.name in self._devices_list:
-            message += emoji.emojize(':flashlight: Light: ', use_aliases=True) + f"{'on' if self._light_device.device_state else 'off'}\n"
+            message += emoji.emojize(' :flashlight: Light: ', use_aliases=True) + f"{'on' if self._light_device.device_state else 'off'}\n"
         if self._psu_device and self._psu_device.name in self._devices_list:
-            message += emoji.emojize(':electric_plug: PSU: ', use_aliases=True) + f"{'on' if self._psu_device.device_state else 'off'}\n"
+            message += emoji.emojize(' :electric_plug: PSU: ', use_aliases=True) + f"{'on' if self._psu_device.device_state else 'off'}\n"
         return message
 
     def execute_command(self, *command) -> None:


### PR DESCRIPTION
Added spaces before power devices emojis' so that the design of all emoji is the same, line starts with a space before emoji.
![was](https://user-images.githubusercontent.com/6440415/153457441-64b9dbaa-4aca-4ac4-abce-ef1bf9d2b129.jpeg)
![became](https://user-images.githubusercontent.com/6440415/153457449-2c77d7e4-c303-462a-8011-308fda5db875.jpeg)

