### PR TITLE
Add check if target temp value exists

### DIFF
--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -221,16 +221,16 @@ class Klippy:
         sens_name = re.sub(r"([A-Z]|\d|_)", r" \1", name).replace('_', '')
         if 'power' in value:
             message = emoji.emojize(' :hotsprings: ', use_aliases=True) + f"{sens_name.title()}: {round(value['temperature'])}"
-            if value['target'] > 0.0 and abs(value['target'] - value['temperature']) > 2:
-                message += emoji.emojize(' :arrow_right: ', use_aliases=True) + f"{round(value['target'])}"
+            if 'target' in value:
+                if value['target'] > 0.0 and abs(value['target'] - value['temperature']) > 2:
+                    message += emoji.emojize(' :arrow_right: ', use_aliases=True) + f"{round(value['target'])}"
             if value['power'] > 0.0:
                 message += emoji.emojize(' :fire: ', use_aliases=True)
         elif 'speed' in value:
             message = emoji.emojize(' :tornado: ', use_aliases=True) + f"{sens_name.title()}: {round(value['temperature'])}"
-            if value['target'] > 0.0 and abs(value['target'] - value['temperature']) > 2:
-                message += emoji.emojize(' :arrow_right: ', use_aliases=True) + f"{round(value['target'])}"
-            if value['speed'] > 0.0:
-                message += emoji.emojize(' :wind_face: ', use_aliases=True)
+            if 'target' in value:
+                if value['target'] > 0.0 and abs(value['target'] - value['temperature']) > 2:
+                    message += emoji.emojize(' :arrow_right: ', use_aliases=True) + f"{round(value['target'])}"
         else:
             message = emoji.emojize(' :thermometer: ', use_aliases=True) + f"{sens_name.title()}: {round(value['temperature'])}"
         message += '\n'


### PR DESCRIPTION
Sometimes the bot can't generate a status message if status_message_heaters is enabled, as I found out when the "target" attribute was missing in the response from the Moonraker or so on, so I add additional check to avoid it.


```
__main__ - ERROR - Exception while handling an update:
Traceback (most recent call last):
  File "/home/endy/moonraker-telegram-bot-env/lib/python3.9/site-packages/telegram/ext/utils/promise.py", line 96, in run
    self._result = self.pooled_function(*self.args, **self.kwargs)
  File "/home/endy/moonraker-telegram-bot/bot/main.py", line 109, in status
    notifier.update_status()
  File "/home/endy/moonraker-telegram-bot/bot/notifications.py", line 276, in update_status
    self._schedule_notification()
  File "/home/endy/moonraker-telegram-bot/bot/notifications.py", line 193, in _schedule_notification
    mess = escape_markdown(self._klippy.get_print_stats(message), version=2)
  File "/home/endy/moonraker-telegram-bot/bot/klippy.py", line 318, in get_print_stats
    message = self._get_printing_file_info(message_pre) + self._get_sensors_message()
  File "/home/endy/moonraker-telegram-bot/bot/klippy.py", line 243, in _get_sensors_message
    message += self.sensor_message(name, value)
  File "/home/endy/moonraker-telegram-bot/bot/klippy.py", line 225, in sensor_message
    if value['target'] > 0.0 and abs(value['target'] - value['temperature']) > 2:
KeyError: 'target'
```