### PR TITLE
Fixed preview when Gcode is located in a subfolder

### DIFF
--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -169,9 +169,12 @@ class Klippy:
         self.filament_total = resp['filament_total'] if 'filament_total' in resp else 0.0
         self.filament_weight = resp['filament_weight_total'] if 'filament_weight_total' in resp else 0.0
 
-        if 'thumbnails' in resp:
+        if 'thumbnails' and 'filename' in resp:
             thumb = max(resp['thumbnails'], key=lambda el: el['size'])
-            self._thumbnail_path = thumb['relative_path']
+            file_dir = resp['filename'].rpartition('/')[0]
+            if file_dir:
+                self._thumbnail_path = file_dir + '/'
+            self._thumbnail_path += thumb['relative_path']
 
     def _get_full_marco_list(self) -> List[str]:
         resp = requests.get(f'http://{self._host}/printer/objects/list', headers=self._headers)
@@ -374,10 +377,13 @@ class Klippy:
         thumb_path = ''
         if 'thumbnails' in resp:
             thumb = max(resp['thumbnails'], key=lambda el: el['size'])
-            if 'relative_path' in thumb:
-                thumb_path = thumb['relative_path']
+            if 'relative_path' and 'filename' in resp:
+                file_dir = resp['filename'].rpartition('/')[0]
+                if file_dir:
+                    thumb_path = file_dir + '/'
+                thumb_path += thumb['relative_path']
             else:
-                logger.error(f"Thumbnail relative_path not found in {resp}")
+                logger.error(f"Thumbnail relative_path and filename not found in {resp}")
 
         return self._populate_with_thumb(thumb_path, message)
 


### PR DESCRIPTION
If Gcode is not in the root, but in a subfolder, then we get "no preview" because we are requesting a preview without considering the folder where Gcode itself is located.
Fixed this both when viewing files and at the start of printing.
![1](https://user-images.githubusercontent.com/6440415/153720196-3e4eed63-91b5-4787-b672-303e01b8ffa2.jpeg)
![2](https://user-images.githubusercontent.com/6440415/153720207-430ea41d-a5ef-404e-acda-25d070f0cbe6.jpeg)
![3](https://user-images.githubusercontent.com/6440415/153720210-66b2df97-2914-4b48-bf58-64afdf00f0f3.jpeg)
![4](https://user-images.githubusercontent.com/6440415/153720209-26bd7f92-d57e-4179-aeff-6b28bc589b1f.jpeg)
