### PR TITLE
Update main.py

### DIFF
--- a/bot/camera.py
+++ b/bot/camera.py
@@ -487,7 +487,7 @@ class Camera:
             info_mess.edit_text(text="Images recoding")
             last_update_time = time.time()
             for fnum, filename in enumerate(photos):
-                if time.time() >= last_update_time + 3:
+                if time.time() >= last_update_time + 10:
                     info_mess.edit_text(text=f"Images recoded {fnum}/{photo_count}")
                     last_update_time = time.time()
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -206,7 +206,7 @@ def check_unfinished_lapses():
     )
     reply_markup = InlineKeyboardMarkup(files_keys)
     bot_updater.bot.send_message(
-        configWrap.bot.chat_id,
+        configWrap.secrets.chat_id,
         text="Unfinished timelapses found\nBuild unfinished timelapse?",
         reply_markup=reply_markup,
         disable_notification=notifier.silent_status,


### PR DESCRIPTION
When starting the bot with an unfinished timelapse, an error occurs due to an invalid variable chat_id.
For a telegram 3 seconds is too short, gives an error: Flood control exceeded.