### PR TITLE
Fixed paths to be compatible with the new moonraker version

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,10 +6,10 @@ SYSTEMDDIR="/etc/systemd/system"
 MOONRAKER_BOT_SERVICE="moonraker-telegram-bot.service"
 MOONRAKER_BOT_ENV="${HOME}/moonraker-telegram-bot-env"
 MOONRAKER_BOT_DIR="${HOME}/moonraker-telegram-bot"
-MOONRAKER_BOT_LOG="${HOME}/klipper_logs/telegram.log"
-MOONRAKER_BOT_CONF="${HOME}/klipper_config"
-KLIPPER_CONF_DIR="${HOME}/klipper_config"
-KLIPPER_LOGS_DIR="${HOME}/klipper_logs"
+MOONRAKER_BOT_LOG="${HOME}/printer_data/logs/telegram.log"
+MOONRAKER_BOT_CONF="${HOME}/printer_data/config"
+KLIPPER_CONF_DIR="${HOME}/printer_data/config"
+KLIPPER_LOGS_DIR="${HOME}/printer_data/logs"
 CURRENT_USER=${USER}
 
 


### PR DESCRIPTION
The latest moonraker update expects the config, log and other paths to be in `~/printer_data/...` now: https://moonraker.readthedocs.io/en/latest/installation/#data-folder-structure

Old installations usually sym link the new paths to the old paths which means that these changes should still work for everyone.