### PR TITLE
ci: add armv7 and arm64/v8 to docker build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,3 +68,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8


### PR DESCRIPTION
The Docker image is currently only available for `linux/amd64`.  
As the target audience is usually using SBCs, Images for platforms `armv7` and `arm64/v8` should also be available.

-Markus