### PR TITLE
Add ability to pass multiple configs

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -1055,6 +1055,7 @@ if __name__ == "__main__":
         "-c",
         "--configfile",
         default="./telegram.conf",
+        nargs="+",
         metavar="<configfile>",
         help="Location of moonraker telegram bot configuration file",
     )


### PR DESCRIPTION
This change adds the ability to pass mutliple configuration files this is useful for moving common configuration sections to a separate config file. Values are overridden in the order in which the config files are passed with '-c'.