### PR TITLE
add functionality to display ip on printer online

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -10,12 +10,12 @@ import os
 from pathlib import Path
 import re
 import signal
+import socket
 import sys
 import tarfile
 import time
 from typing import Dict, List, Union
 from zipfile import ZipFile
-import socket
 
 from apscheduler.events import EVENT_JOB_ERROR  # type: ignore
 from apscheduler.schedulers.background import BackgroundScheduler  # type: ignore
@@ -998,10 +998,10 @@ def greeting_message(bot: telegram.Bot) -> None:
 def get_local_ip():
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
-        s.connect(('192.255.255.255', 1))
+        s.connect(("192.255.255.255", 1))
         IP = s.getsockname()[0]
     except:
-        IP = '127.0.0.1'
+        IP = "127.0.0.1"
     finally:
         s.close()
     return IP

--- a/bot/main.py
+++ b/bot/main.py
@@ -15,6 +15,7 @@ import tarfile
 import time
 from typing import Dict, List, Union
 from zipfile import ZipFile
+import socket
 
 from apscheduler.events import EVENT_JOB_ERROR  # type: ignore
 from apscheduler.schedulers.background import BackgroundScheduler  # type: ignore
@@ -978,7 +979,7 @@ def greeting_message(bot: telegram.Bot) -> None:
     if response:
         mess += escape(f"Bot online, no moonraker connection!\n {response} \nFailing...")
     else:
-        mess += "Printer online"
+        mess += "Printer online on " + get_local_ip()
         if configWrap.configuration_errors:
             mess += escape(klippy.get_versions_info(bot_only=True)) + configWrap.configuration_errors
 
@@ -994,6 +995,16 @@ def greeting_message(bot: telegram.Bot) -> None:
     klippy.add_bot_announcements_feed()
     check_unfinished_lapses(bot)
 
+def get_local_ip():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(('192.255.255.255', 1))
+        IP = s.getsockname()[0]
+    except:
+        IP = '127.0.0.1'
+    finally:
+        s.close()
+    return IP
 
 def start_bot(bot_token, socks):
     request_kwargs = {

--- a/bot/main.py
+++ b/bot/main.py
@@ -995,16 +995,18 @@ def greeting_message(bot: telegram.Bot) -> None:
     klippy.add_bot_announcements_feed()
     check_unfinished_lapses(bot)
 
+
 def get_local_ip():
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
-        s.connect(("192.255.255.255", 1))
-        IP = s.getsockname()[0]
-    except:
-        IP = "127.0.0.1"
+        sock.connect(("192.255.255.255", 1))
+        ip_address = sock.getsockname()[0]
+    except: # pylint: disable=W0702
+        ip_address = "127.0.0.1"
     finally:
-        s.close()
-    return IP
+        sock.close()
+    return ip_address
+
 
 def start_bot(bot_token, socks):
     request_kwargs = {

--- a/bot/main.py
+++ b/bot/main.py
@@ -1001,7 +1001,7 @@ def get_local_ip():
     try:
         sock.connect(("192.255.255.255", 1))
         ip_address = sock.getsockname()[0]
-    except: # pylint: disable=W0702
+    except:  # pylint: disable=W0702
         ip_address = "127.0.0.1"
     finally:
         sock.close()


### PR DESCRIPTION
Added the function of showing the IP address of the printer in the local network. There are problems when the router issues different IP addresses every time it is turned on and there is no possibility of fixing. This usually happens in educational organizations or other networks where it is impossible for an ordinary user to control the network. With this functionality, when the bot starts, Telegram receives a message with an address that you can click on and immediately get into the Fluid or Mainsail web interface or use it to connect via FTP or SSH.
<img width="194" alt="image" src="https://user-images.githubusercontent.com/33718372/231422477-0180d84d-8239-431a-a4a9-4c013a5e3631.png">
