### PR TITLE
Don't create timelapse folder unless timelapse is enabled

### DIFF
--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -303,7 +303,8 @@ class TimelapseConfig(ConfigHelper):
 
     def _init_paths(self):
         self.base_dir = os.path.expanduser(self.base_dir)
-        Path(self.base_dir).mkdir(parents=True, exist_ok=True)
+        if self.enabled:
+            Path(self.base_dir).mkdir(parents=True, exist_ok=True)
         if self.ready_dir:
             self.ready_dir = os.path.expanduser(self.ready_dir)
 


### PR DESCRIPTION
Don't create folder in home dir by default.

Otherwise when user sets timelapse.base_dir, this also enabled timelapse.