### PR TITLE
Custom printer name setup in config

### DIFF
--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -325,6 +325,7 @@ class TelegramUIConfig(ConfigHelper):
         "show_private_macros",
         "eta_source",
         "status_message_m117_update",
+        "printer_name",
     ]
     _MESSAGE_CONTENT = [
         "progress",
@@ -366,6 +367,7 @@ class TelegramUIConfig(ConfigHelper):
         self.show_private_macros: bool = self._get_boolean("show_private_macros", default=False)
         self.pin_status_single_message: bool = self._get_boolean("pin_status_single_message", default=False)  # Todo: implement
         self.status_message_m117_update: bool = self._get_boolean("status_message_m117_update", default=False)
+        self.printer_name: str = self._get_str("printer_name", default="Printer")
 
 
 class StatusMessageContentConfig(ConfigHelper):

--- a/bot/main.py
+++ b/bot/main.py
@@ -978,7 +978,7 @@ def greeting_message(bot: telegram.Bot) -> None:
     if response:
         mess += escape(f"Bot online, no moonraker connection!\n {response} \nFailing...")
     else:
-        mess += "Printer online"
+        mess += configWrap.telegram_ui.printer_name + " online"
         if configWrap.configuration_errors:
             mess += escape(klippy.get_versions_info(bot_only=True)) + configWrap.configuration_errors
 


### PR DESCRIPTION
add functionality to set the printer name via own setting in config file. Just add under [telegram_ui] the option "printer_name: YourPrinterName" and it shows your custom printer name at startup. Default value, if not set, is "Printer" so the default behaviour stays the same.

![grafik](https://github.com/nlef/moonraker-telegram-bot/assets/91900310/65ea46b2-4eb3-4efd-b8be-062751495973)
