### PR TITLE
fix possible KeyError

### DIFF
--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -250,8 +250,8 @@ class Klippy:
             logger.warning("bad response for file request %s", response.reason)
         resp = orjson.loads(response.text)["result"]
         self._printing_filename = new_value
-        self.file_estimated_time = resp["estimated_time"] if resp["estimated_time"] else 0.0
-        self.file_print_start_time = resp["print_start_time"] if resp["print_start_time"] else time.time()
+        self.file_estimated_time = resp["estimated_time"] if resp.get("estimated_time") else 0.0
+        self.file_print_start_time = resp["print_start_time"] if resp.get("print_start_time") else time.time()
         self.filament_total = resp["filament_total"] if "filament_total" in resp else 0.0
         self.filament_weight = resp["filament_weight_total"] if "filament_weight_total" in resp else 0.0
 


### PR DESCRIPTION
It is possible to get an `KeyError` if Gcode file does not contain fields

Something like that:
```
 Traceback (most recent call last):
   File "/home/mks/moonraker-telegram-bot-env/lib/python3.7/site-packages/telegram/ext/utils/promise.py", line 96, in run
     self._result = self.pooled_function(*self.args, **self.kwargs)
   File "/home/mks/moonraker-telegram-bot/bot/main.py", line 152, in status
     mess = escape(klippy.get_status())
   File "/home/mks/moonraker-telegram-bot/bot/klippy.py", line 402, in get_status
     self.printing_filename = print_stats["filename"]
   File "/home/mks/moonraker-telegram-bot/bot/klippy.py", line 192, in printing_filename
     self.file_estimated_time = resp["estimated_time"] if resp["estimated_time"] else 0.0
 KeyError: 'estimated_time'
```
