### PR TITLE
Do not crash when OpenCV is built without GUI support

### DIFF
--- a/bot/camera.py
+++ b/bot/camera.py
@@ -499,7 +499,11 @@ class Camera:
                 out.write(img)
 
             out.release()
-            cv2.destroyAllWindows()
+            try:
+                cv2.destroyAllWindows()
+            except cv2.error:
+                # OpenCV was likely built without GUI support
+                pass
             del out
 
         del photos, img, layers


### PR DESCRIPTION
Without this change I am getting the following error when trying to build a timelapse:

```
Sep 25 16:37:27 3d moonraker-telegram-bot-start[1056]: 2024-09-25 16:37:27,719 - __main__ - ERROR - Exception while handling an update:                                                                              
Sep 25 16:37:27 3d moonraker-telegram-bot-start[1056]: Traceback (most recent call last):
Sep 25 16:37:27 3d moonraker-telegram-bot-start[1056]:   File "/nix/store/ygzl5715bnhvmqica1r1mxikyrvaa980-python3-3.11.9-env/lib/python3.11/site-packages/telegram/ext/dispatcher.py", line 557, in process_update
Sep 25 16:37:27 3d moonraker-telegram-bot-start[1056]:     handler.handle_update(update, self, check, context)                                                                                                       
Sep 25 16:37:27 3d moonraker-telegram-bot-start[1056]:   File "/nix/store/ygzl5715bnhvmqica1r1mxikyrvaa980-python3-3.11.9-env/lib/python3.11/site-packages/telegram/ext/handler.py", line 199, in handle_update
Sep 25 16:37:27 3d moonraker-telegram-bot-start[1056]:     return self.callback(update, context)                                                                                                                     
Sep 25 16:37:27 3d moonraker-telegram-bot-start[1056]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Sep 25 16:37:27 3d moonraker-telegram-bot-start[1056]:   File "/nix/store/fd3zp42cqhy3ipq2g1dkm3d6q4pl6j9s-moonraker-telegram-bot-1.5.0/lib/bot/main.py", line 427, in button_lapse_handler
Sep 25 16:37:27 3d moonraker-telegram-bot-start[1056]:     ) = cameraWrap.create_timelapse_for_file(lapse_name, info_mess)
Sep 25 16:37:27 3d moonraker-telegram-bot-start[1056]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Sep 25 16:37:27 3d moonraker-telegram-bot-start[1056]:   File "/nix/store/fd3zp42cqhy3ipq2g1dkm3d6q4pl6j9s-moonraker-telegram-bot-1.5.0/lib/bot/camera.py", line 425, in create_timelapse_for_file
Sep 25 16:37:27 3d moonraker-telegram-bot-start[1056]:     return self._create_timelapse(filename, filename, info_mess)
Sep 25 16:37:27 3d moonraker-telegram-bot-start[1056]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Sep 25 16:37:27 3d moonraker-telegram-bot-start[1056]:   File "/nix/store/fd3zp42cqhy3ipq2g1dkm3d6q4pl6j9s-moonraker-telegram-bot-1.5.0/lib/bot/camera.py", line 502, in _create_timelapse
Sep 25 16:37:27 3d moonraker-telegram-bot-start[1056]:     cv2.destroyAllWindows()
Sep 25 16:37:27 3d moonraker-telegram-bot-start[1056]: cv2.error: OpenCV(4.9.0) /build/source/modules/highgui/src/window.cpp:1266: error: (-2:Unspecified error) The function is not implemented. Rebuild the library with Windows, GTK+ 2.x or Cocoa support. If you are on Ubuntu or Debian, install libgtk2.0-dev and pkg-config, then re-run cmake or configure script in function 'cvDestroyAllWindows'
```