### PR TITLE
add message_thread_id support for groups

### DIFF
--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -301,14 +301,18 @@ class NotifierConfig(ConfigHelper):
         els = [self._get_group_with_thread_id(el) for el in self._get_list("groups", default=[], el_type=str)]
         return list(ell for ell in els if ell is not None)
 
-    @staticmethod
-    def _get_group_with_thread_id(group_id: str) -> Optional[Tuple[int, Optional[int]]]:
-        parts = group_id.split(":")
-        if len(parts) == 2:
-            return int(parts[0]), int(parts[1])
-        elif len(parts) == 1:
-            return int(parts[0]), None
-        else:
+    def _get_group_with_thread_id(self, group_id: str) -> Optional[Tuple[int, Optional[int]]]:
+        try:
+            parts = group_id.split(":")
+            if len(parts) == 2:
+                return int(parts[0]), int(parts[1])
+            elif len(parts) == 1:
+                return int(parts[0]), None
+            else:
+                self._parsing_errors.append(f"Malformed group_id `{group_id}`")
+                return None
+        except Exception as ex:
+            self._parsing_errors.append(f"Error parsing group_id `{group_id}` \n {ex}")
             return None
 
 

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -3,7 +3,7 @@ import os
 import pathlib
 from pathlib import Path
 import re
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 
 class ConfigHelper:
@@ -294,8 +294,22 @@ class NotifierConfig(ConfigHelper):
         self.percent: int = self._get_int("percent", default=0, min_value=0)
         self.height: float = self._get_float("height", default=0, min_value=0.0)
         self.interval: int = self._get_int("time", default=0, min_value=0)
-        self.notify_groups: List[int] = self._get_list("groups", default=[], el_type=int)
+        self.notify_groups: List[Tuple[int, Optional[int]]] = self._get_groups_list()
         self.group_only: bool = self._get_boolean("group_only", default=False)
+
+    def _get_groups_list(self) -> List[Tuple[int, Optional[int]]]:
+        els = [self._get_group_with_thread_id(el) for el in self._get_list("groups", default=[], el_type=str)]
+        return list(ell for ell in els if ell is not None)
+
+    @staticmethod
+    def _get_group_with_thread_id(group_id: str) -> Optional[Tuple[int, Optional[int]]]:
+        parts = group_id.split(":")
+        if len(parts) == 2:
+            return int(parts[0]), int(parts[1])
+        elif len(parts) == 1:
+            return int(parts[0]), None
+        else:
+            return None
 
 
 class TimelapseConfig(ConfigHelper):

--- a/bot/main.py
+++ b/bot/main.py
@@ -135,9 +135,6 @@ async def unknown_chat(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
         logger.warning("Undefined effective chat")
         return
 
-    if update.effective_chat.id in configWrap.notifications.notify_groups:
-        return
-
     if update.effective_chat.id < 0 or update.effective_message is None:
         return
 


### PR DESCRIPTION
The format for specifying groups in the config has been expanded. Now you can specify either just a group or a group with a message_thread_id
Format - `groups`: `group_id:message_thread_id`, `groupd id`

Example - `groups`:`-10024765042348:2`, `-10015514833324`
#349