### PR TITLE
Add option to disable reply keyboard

### DIFF
--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -369,6 +369,7 @@ class TelegramUIConfig(ConfigHelper):
         "silent_status",
         "pin_status_single_message",
         "send_greeting_message",
+        "send_reply_keyboard",
         "buttons",
         "progress_update_message",
         "include_macros_in_command_list",
@@ -409,6 +410,7 @@ class TelegramUIConfig(ConfigHelper):
             )
         )
         self.progress_update_message: bool = self._get_boolean("progress_update_message", default=False)
+        self.send_reply_keyboard: bool = self._get_boolean("send_reply_keyboard", default=True)
         self.silent_progress: bool = self._get_boolean("silent_progress", default=False)
         self.silent_commands: bool = self._get_boolean("silent_commands", default=False)
         self.silent_status: bool = self._get_boolean("silent_status", default=False)

--- a/bot/main.py
+++ b/bot/main.py
@@ -1190,12 +1190,13 @@ async def greeting_message(bot: telegram.Bot) -> None:
             if config_wrap.configuration_errors:
                 mess += await klippy.get_versions_info(bot_only=True) + config_wrap.configuration_errors
 
+        use_keyboard = configWrap.telegram_ui.send_reply_keyboard
         await bot.send_message(
             config_wrap.secrets.chat_id,
             text=mess,
             parse_mode=ParseMode.HTML,
-            reply_markup=ReplyKeyboardMarkup(create_keyboard(), resize_keyboard=True),
             disable_notification=notifier.silent_status,
+            reply_markup=ReplyKeyboardMarkup(create_keyboard(), resize_keyboard=True) if use_keyboard else None,
         )
 
     await bot.set_my_commands(commands=prepare_commands_list(await klippy.get_macros_force(), config_wrap.telegram_ui.include_macros_in_command_list))

--- a/bot/main.py
+++ b/bot/main.py
@@ -27,7 +27,20 @@ import emoji
 import httpx
 import orjson
 import telegram
-from telegram import BotCommand, InlineKeyboardButton, InlineKeyboardMarkup, InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo, Message, MessageEntity, ReplyKeyboardMarkup, Update
+from telegram import (
+    BotCommand,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    InputMediaAudio,
+    InputMediaDocument,
+    InputMediaPhoto,
+    InputMediaVideo,
+    Message,
+    MessageEntity,
+    ReplyKeyboardMarkup,
+    ReplyKeyboardRemove,
+    Update,
+)
 from telegram.constants import ChatAction, ParseMode
 from telegram.error import BadRequest
 from telegram.ext import Application, CallbackContext, CallbackQueryHandler, CommandHandler, ContextTypes, MessageHandler, filters
@@ -1190,13 +1203,13 @@ async def greeting_message(bot: telegram.Bot) -> None:
             if config_wrap.configuration_errors:
                 mess += await klippy.get_versions_info(bot_only=True) + config_wrap.configuration_errors
 
-        use_keyboard = configWrap.telegram_ui.send_reply_keyboard
+        use_keyboard = config_wrap.telegram_ui.send_reply_keyboard
         await bot.send_message(
             config_wrap.secrets.chat_id,
             text=mess,
             parse_mode=ParseMode.HTML,
             disable_notification=notifier.silent_status,
-            reply_markup=ReplyKeyboardMarkup(create_keyboard(), resize_keyboard=True) if use_keyboard else None,
+            reply_markup=ReplyKeyboardMarkup(create_keyboard(), resize_keyboard=True) if use_keyboard else ReplyKeyboardRemove(),
         )
 
     await bot.set_my_commands(commands=prepare_commands_list(await klippy.get_macros_force(), config_wrap.telegram_ui.include_macros_in_command_list))


### PR DESCRIPTION
Hi! First of all, thank you for this wonderful project, it's been a great asset to my 3D printing experience!

I've made a few small changes to accommodate my own preferences when it comes to Telegram Bot UX. I'm using these changes for myself, but I'd like to offer them to be integrated upstream, if you like them.

In this change, I'm adding a configuration option that disables the automatic reply keyboard that is sent together with the greeting message. I like the greeting - it lets me know immediately that everything is up and running - but the reply keyboard is, in my opinion, rather annoying. It takes away too much space on my screen, and I prefer using the commands menu or autocomplete.

I've made it so the default option is to show the keyboard (like before), but users who don't like it get the option to disable it.