### PR TITLE
Add inline button to update status messages

### DIFF
--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -383,6 +383,7 @@ class TelegramUIConfig(ConfigHelper):
         "eta_source",
         "status_message_m117_update",
         "require_confirmation",
+        "status_update_button",
     ]
     _MESSAGE_CONTENT = [
         "progress",
@@ -423,6 +424,7 @@ class TelegramUIConfig(ConfigHelper):
         self.pin_status_single_message: bool = self._get_boolean("pin_status_single_message", default=True)
         self.status_message_m117_update: bool = self._get_boolean("status_message_m117_update", default=False)
         self.send_greeting_message: bool = self._get_boolean("send_greeting_message", default=True)
+        self.status_update_button: bool = self._get_boolean("status_update_button", default=False)
         self.require_confirmation: List[str] = self._get_list(
             "require_confirmation", default=["logs", "logs_upload", "shutdown", "restart", "cancel", "fw_restart", "emergency", "reboot", "power", "bot_restart"]
         )

--- a/bot/main.py
+++ b/bot/main.py
@@ -148,20 +148,40 @@ async def unknown_chat(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def status_no_confirm(effective_message: Message) -> None:
+    is_inline_button_press = effective_message.from_user is not None and effective_message.from_user.id == effective_message.get_bot().id
     if klippy.printing and not configWrap.notifications.group_only:
         notifier.update_status()
         time.sleep(configWrap.camera.light_timeout + 1.5)
-        await effective_message.delete()
+        if not is_inline_button_press:
+            await effective_message.delete()
     else:
         text = await klippy.get_status()
-        message = TelegramMessageRepr(text, parse_mode=ParseMode.HTML, silent=notifier.silent_commands)
+        inline_keyboard = None
+        if configWrap.telegram_ui.status_update_button:
+            inline_keyboard = InlineKeyboardMarkup(
+                [
+                    [
+                        InlineKeyboardButton(
+                            text="Update",
+                            callback_data="updstatus",
+                        )
+                    ]
+                ]
+            )
+        message = TelegramMessageRepr(text, parse_mode=ParseMode.HTML, silent=notifier.silent_commands, reply_markup=inline_keyboard)
         if cameraWrap.enabled:
             loop_loc = asyncio.get_running_loop()
             with await loop_loc.run_in_executor(executors_pool, cameraWrap.take_photo) as bio:
-                await message.send_as_reply(effective_message, photo=bio)
+                if is_inline_button_press:
+                    await message.update_existing(effective_message, photo=bio)
+                else:
+                    await message.send_as_reply(effective_message, photo=bio)
                 bio.close()
         else:
-            await message.send_as_reply(effective_message)
+            if is_inline_button_press:
+                await message.update_existing(effective_message)
+            else:
+                await message.send_as_reply(effective_message)
 
 
 async def status(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
@@ -671,7 +691,8 @@ async def button_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         logger.error("Undefined callback_query.data for %s", query.to_json())
         return
 
-    await context.bot.send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING)
+    if "updstatus" not in query.data:
+        await context.bot.send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING)
 
     await query.answer()
     if query.data == "do_nothing":
@@ -685,6 +706,9 @@ async def button_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         cameraWrap.cleanup_unfinished_lapses()
     elif "gcode:" in query.data:
         await ws_helper.execute_ws_gcode_script(query.data.replace("gcode:", ""))
+    elif "updstatus" in query.data:
+        await status_no_confirm(update.effective_message)
+        delete_query = False
     elif update.effective_message.reply_to_message is None:
         logger.error("Undefined reply_to_message for %s", update.effective_message.to_json())
     elif query.data == "emergency_stop":

--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -9,9 +9,10 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from apscheduler.schedulers.base import BaseScheduler  # type: ignore
 from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup, InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo, Message
-from telegram.constants import ChatAction, ParseMode
+from telegram.constants import ChatAction
 from telegram.error import BadRequest
 from telegram.helpers import escape_markdown
+from telegram_helper import TelegramMessageRepr
 
 from camera import Camera
 from configuration import ConfigWrapper
@@ -61,7 +62,7 @@ class Notifier:
 
         self._status_message: Optional[Message] = None
         self._bzz_mess_id: int = 0
-        self._groups_status_mesages: Dict[int, Message] = {}
+        self._groups_status_messages: Dict[int, Message] = {}
 
         if logging_handler:
             logger.addHandler(logging_handler)
@@ -127,7 +128,7 @@ class Notifier:
             self._interval = new_value
             self._reschedule_notifier_timer()
 
-    async def _send_message(self, message: str, silent: bool, group_only: bool = False, manual: bool = False) -> None:
+    async def _send_message(self, message: TelegramMessageRepr, group_only: bool = False, manual: bool = False) -> None:
         if not group_only:
             await self._bot.send_chat_action(chat_id=self._chat_id, action=ChatAction.TYPING)
             if self._status_message and not manual:
@@ -137,46 +138,29 @@ class Notifier:
                     except BadRequest as badreq:
                         logger.warning("Failed deleting bzz message \n%s", badreq)
                         self._bzz_mess_id = 0
-
-                if self._status_message.caption:
-                    await self._status_message.edit_caption(caption=message, parse_mode=ParseMode.MARKDOWN_V2)
-                else:
-                    await self._status_message.edit_text(text=message, parse_mode=ParseMode.MARKDOWN_V2)
+                await message.update_existing(self._status_message)
 
                 if self._progress_update_message:
-                    mes = await self._bot.send_message(self._chat_id, text="Status has been updated\nThis message will be deleted", disable_notification=silent)
+                    mes = await self._bot.send_message(self._chat_id, text="Status has been updated\nThis message will be deleted", disable_notification=message.is_silent())
                     self._bzz_mess_id = mes.message_id
             else:
-                sent_message = await self._bot.send_message(
-                    self._chat_id,
-                    text=message,
-                    parse_mode=ParseMode.MARKDOWN_V2,
-                    disable_notification=silent,
-                )
+
+                sent_message = await message.send(self._bot, self._chat_id)
                 if not self._status_message and not manual:
                     self._status_message = sent_message
 
         for group, message_thread_id in self._notify_groups:
             await self._bot.send_chat_action(chat_id=group, message_thread_id=message_thread_id, action=ChatAction.TYPING)
-            if group in self._groups_status_mesages and not manual:
-                mess = self._groups_status_mesages[group]
-                if mess.caption:
-                    await mess.edit_caption(caption=message, parse_mode=ParseMode.MARKDOWN_V2)
-                else:
-                    await mess.edit_text(text=message, parse_mode=ParseMode.MARKDOWN_V2)
+            if group in self._groups_status_messages and not manual:
+                mess = self._groups_status_messages[group]
+                await message.update_existing(mess)
             else:
-                sent_message = await self._bot.send_message(
-                    chat_id=group,
-                    message_thread_id=message_thread_id,
-                    text=message,
-                    parse_mode=ParseMode.MARKDOWN_V2,
-                    disable_notification=silent,
-                )
-                if group in self._groups_status_mesages or manual:
+                sent_message = await message.send(self._bot, group, message_thread_id=message_thread_id)
+                if group in self._groups_status_messages or manual:
                     continue
-                self._groups_status_mesages[group] = sent_message
+                self._groups_status_messages[group] = sent_message
 
-    async def _send_photo(self, group_only, manual, message, silent):
+    async def _send_photo(self, group_only, manual, message):
         loop = asyncio.get_running_loop()
         with await loop.run_in_executor(self._executors_pool, self._cam_wrap.take_photo) as photo:
             if not group_only:
@@ -188,54 +172,37 @@ class Notifier:
                         except BadRequest as badreq:
                             logger.warning("Failed deleting bzz message \n%s", badreq)
                             self._bzz_mess_id = 0
-
-                    # Fixme: check if media in message!
-                    await self._status_message.edit_media(media=InputMediaPhoto(photo))
-                    await self._status_message.edit_caption(caption=message, parse_mode=ParseMode.MARKDOWN_V2)
+                    await message.update_existing(self._status_message)
 
                     if self._progress_update_message:
-                        mes = await self._bot.send_message(self._chat_id, text="Status has been updated\nThis message will be deleted", disable_notification=silent)
+                        mes = await self._bot.send_message(self._chat_id, text="Status has been updated\nThis message will be deleted", disable_notification=message.is_silent())
                         self._bzz_mess_id = mes.message_id
 
                 else:
-                    sent_message = await self._bot.send_photo(
-                        self._chat_id,
-                        photo=photo,
-                        caption=message,
-                        parse_mode=ParseMode.MARKDOWN_V2,
-                        disable_notification=silent,
-                    )
+                    sent_message = await message.send(self._bot, self._chat_id, photo=photo)
                     if not self._status_message and not manual:
                         self._status_message = sent_message
 
             for group, message_thread_id in self._notify_groups:
                 photo.seek(0)
                 await self._bot.send_chat_action(chat_id=group, message_thread_id=message_thread_id, action=ChatAction.UPLOAD_PHOTO)
-                if group in self._groups_status_mesages and not manual:
-                    mess = self._groups_status_mesages[group]
-                    await mess.edit_media(media=InputMediaPhoto(photo))
-                    await mess.edit_caption(caption=message, parse_mode=ParseMode.MARKDOWN_V2)
+                if group in self._groups_status_messages and not manual:
+                    mess = self._groups_status_messages[group]
+                    await message.update_existing(mess, photo=photo)
                 else:
-                    sent_message = await self._bot.send_photo(
-                        chat_id=group,
-                        message_thread_id=message_thread_id,
-                        photo=photo,
-                        caption=message,
-                        parse_mode=ParseMode.MARKDOWN_V2,
-                        disable_notification=silent,
-                    )
-                    if group in self._groups_status_mesages or manual:
+                    sent_message = await message.send(self._bot, group, photo=photo, message_thread_id=message_thread_id)
+                    if group in self._groups_status_messages or manual:
                         continue
-                    self._groups_status_mesages[group] = sent_message
+                    self._groups_status_messages[group] = sent_message
 
             photo.close()
 
-    async def _notify(self, message: str, silent: bool, group_only: bool = False, manual: bool = False, finish: bool = False) -> None:
+    async def _notify(self, message: TelegramMessageRepr, group_only: bool = False, manual: bool = False, finish: bool = False) -> None:
         try:
             if not self._cam_wrap.enabled:
-                await self._send_message(message, silent, manual)
+                await self._send_message(message, manual)
             else:
-                await self._send_photo(group_only, manual, message, silent)
+                await self._send_photo(group_only, manual, message)
         except Exception as ex:
             logger.error(ex)
         finally:
@@ -246,11 +213,13 @@ class Notifier:
     def send_error(self, message: str, logs_upload: bool = False) -> None:
         if logs_upload:
             message += "\nUpload logs to analyzer /logs_upload\nSend logs to chat /logs"
+        tg_message = TelegramMessageRepr(
+            text=message,
+        )
         self._sched.add_job(
             self._send_message,
             kwargs={
-                "message": escape_markdown(message, version=2),
-                "silent": False,
+                "message": tg_message,
                 "manual": True,
             },
             misfire_grace_time=None,
@@ -260,11 +229,13 @@ class Notifier:
         )
 
     def send_error_with_photo(self, message: str) -> None:
+        tg_message = TelegramMessageRepr(
+            text=message,
+        )
         self._sched.add_job(
             self._notify,
             kwargs={
-                "message": escape_markdown(message, version=2),
-                "silent": False,
+                "message": tg_message,
                 "manual": True,
             },
             misfire_grace_time=None,
@@ -274,11 +245,14 @@ class Notifier:
         )
 
     def send_printer_status_notification(self, message: str) -> None:
+        tg_message = TelegramMessageRepr(
+            text=message,
+            silent=self._silent_status,
+        )
         self._sched.add_job(
             self._send_message,
             kwargs={
-                "message": escape_markdown(message, version=2),
-                "silent": self._silent_status,
+                "message": tg_message,
                 "manual": True,
             },
             misfire_grace_time=None,
@@ -288,11 +262,14 @@ class Notifier:
         )
 
     def send_notification(self, message: str) -> None:
+        tg_message = TelegramMessageRepr(
+            text=message,
+            silent=self._silent_commands,
+        )
         self._sched.add_job(
             self._send_message,
             kwargs={
-                "message": escape_markdown(message, version=2),
-                "silent": self._silent_commands,
+                "message": tg_message,
                 "manual": True,
             },
             misfire_grace_time=None,
@@ -302,11 +279,14 @@ class Notifier:
         )
 
     def send_notification_with_photo(self, message: str) -> None:
+        tg_message = TelegramMessageRepr(
+            text=message,
+            silent=self._silent_commands,
+        )
         self._sched.add_job(
             self._notify,
             kwargs={
-                "message": escape_markdown(message, version=2),
-                "silent": self._silent_commands,
+                "message": tg_message,
                 "manual": True,
             },
             misfire_grace_time=None,
@@ -322,7 +302,7 @@ class Notifier:
         self._last_m117_status = ""
         self._last_tgnotify_status = ""
         self._status_message = None
-        self._groups_status_mesages = {}
+        self._groups_status_messages = {}
         if self._bzz_mess_id != 0:
             try:
                 await self._bot.delete_message(self._chat_id, self._bzz_mess_id)
@@ -340,9 +320,15 @@ class Notifier:
         if "last_update_time" in self._message_parts:
             mess += f"_Last update at {datetime.now():%H:%M:%S}_"
 
+        tg_message = TelegramMessageRepr(
+            text=mess,
+            silent=self._silent_progress,
+            suppress_escaping=True,
+        )
+
         self._sched.add_job(
             self._notify,
-            kwargs={"message": mess, "silent": self._silent_progress, "group_only": self._group_only, "finish": finish},
+            kwargs={"message": tg_message, "group_only": self._group_only, "finish": finish},
             misfire_grace_time=180,
             coalesce=False,
             max_instances=6,
@@ -353,8 +339,7 @@ class Notifier:
         #     self._sched.add_job(
         #         self._notify,
         #         kwargs={
-        #             "message": mess,
-        #             "silent": self._silent_progress,
+        #             "message": tg_message,
         #             "group_only": self._group_only,
         #         },
         #         misfire_grace_time=None,
@@ -363,7 +348,7 @@ class Notifier:
         #         replace_existing=False,
         #     )
         # else:
-        #     self._notify(mess, self._silent_progress, self._group_only)
+        #     self._notify(tg_message, self._group_only)
 
     def schedule_notification(self, progress: int = 0, position_z: int = 0) -> None:
         if not self._klippy.printing or self._klippy.printing_duration <= 0.0 or (self._height == 0 and self._percent == 0):
@@ -432,7 +417,7 @@ class Notifier:
             )
             for group_, message_thread_id in self._notify_groups:
                 bio.seek(0)
-                self._groups_status_mesages[group_] = await self._bot.send_photo(
+                self._groups_status_messages[group_] = await self._bot.send_photo(
                     chat_id=group_,
                     message_thread_id=message_thread_id,
                     photo=bio,
@@ -443,7 +428,7 @@ class Notifier:
         else:
             status_message = await self._bot.send_message(chat_id=self._chat_id, text=message, disable_notification=self.silent_status)
             for group_, message_thread_id in self._notify_groups:
-                self._groups_status_mesages[group_] = await self._bot.send_message(chat_id=group_, message_thread_id=message_thread_id, text=message, disable_notification=self.silent_status)
+                self._groups_status_messages[group_] = await self._bot.send_message(chat_id=group_, message_thread_id=message_thread_id, text=message, disable_notification=self.silent_status)
         self._status_message = status_message
 
         if self._pin_status_single_message:

--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -171,7 +171,7 @@ class Notifier:
                         except BadRequest as badreq:
                             logger.warning("Failed deleting bzz message \n%s", badreq)
                             self._bzz_mess_id = 0
-                    await message.update_existing(self._status_message)
+                    await message.update_existing(self._status_message, photo=photo)
 
                     if self._progress_update_message:
                         mes = await self._bot.send_message(self._chat_id, text="Status has been updated\nThis message will be deleted", disable_notification=message.is_silent())

--- a/bot/telegram_helper.py
+++ b/bot/telegram_helper.py
@@ -1,0 +1,82 @@
+from telegram import InputMediaPhoto
+from telegram.constants import ChatAction, ParseMode
+from telegram.helpers import escape_markdown
+
+
+class TelegramMessageRepr:
+    def __init__(
+        self,
+        text="",
+        parse_mode=ParseMode.MARKDOWN_V2,
+        reply_markup=None,
+        silent=False,
+        suppress_escaping=False,
+    ):
+        if parse_mode == ParseMode.MARKDOWN_V2 and not suppress_escaping:
+            self._text = escape_markdown(text, version=2)
+        else:
+            self._text = text
+        self._parse_mode = parse_mode
+        self._reply_markup = reply_markup
+        self._silent = silent
+
+    def is_silent(self):
+        return self._silent
+
+    async def send_as_reply(self, other_message, photo=None):
+        if photo:
+            await other_message.get_bot().send_chat_action(other_message.chat_id, action=ChatAction.UPLOAD_PHOTO)
+            await other_message.reply_photo(
+                photo=photo,
+                caption=self._text,
+                parse_mode=self._parse_mode,
+                disable_notification=self._silent,
+                reply_markup=self._reply_markup,
+            )
+        else:
+            await other_message.get_bot().send_chat_action(other_message.chat_id, action=ChatAction.TYPING)
+            await other_message.reply_text(
+                self._text,
+                parse_mode=self._parse_mode,
+                disable_notification=self._silent,
+                quote=True,
+                reply_markup=self._reply_markup,
+            )
+
+    async def send(self, bot, chat_id, photo=None, message_thread_id=None):
+        if photo:
+            return await bot.send_photo(
+                chat_id,
+                photo=photo,
+                caption=self._text,
+                parse_mode=self._parse_mode,
+                reply_markup=self._reply_markup,
+                disable_notification=self._silent,
+                message_thread_id=message_thread_id,
+            )
+        else:
+            return await bot.send_message(
+                chat_id,
+                text=self._text,
+                parse_mode=self._parse_mode,
+                reply_markup=self._reply_markup,
+                disable_notification=self._silent,
+                message_thread_id=message_thread_id,
+            )
+
+    async def update_existing(self, other_message, photo=None):
+        if photo:
+            # Fixme: check if media in message!
+            await other_message.edit_media(media=InputMediaPhoto(photo))
+        if other_message.caption:
+            await other_message.edit_caption(
+                caption=self._text,
+                parse_mode=self._parse_mode,
+                reply_markup=self._reply_markup,
+            )
+        else:
+            await other_message.edit_text(
+                text=self._text,
+                parse_mode=self._parse_mode,
+                reply_markup=self._reply_markup,
+            )


### PR DESCRIPTION
Good evening!

I've made a few small changes to accommodate my own preferences when it comes to Telegram Bot UX. I'm using these changes for myself, but I'd like to offer them to be integrated upstream, if you like them.

In this change, I'm adding a configuration option that, when enabled, causes an "update" button to appear under the status message. Pressing this button triggers a manual update of the status, just as if the `/status` command had been used.

Personally, I like inline buttons as a way to interact with bots, and I was missing this feature.

The default is for this button to not show up (like before), but users who want it can now enable it in their config.

To accomplish this change, I refactored the way message data is passed around in the `notifications.py` module (and also, to a lesser extent, in the `main.py` module). I've added a new class that represents a Telegram message to send, with all its parameters. This class is useful when a message is constructed before it is known how exactly that message gets sent (whether it's sent as a reply, or as an update to an existing message...) - the message-specific metadata can get passed around in a bundle, and the method that handles the actual sending doesn't need to know all of the specifics of how this message is supposed to be set up.

Messages can still easily be sent directly. Rather than refactoring every single occurrence of message sending, I am using my new class only where it's most useful. In the future, it can be used in more places if it's beneficial.

Let me know what you think.