### PR TITLE
fix mian.py: make start delay configureable

### DIFF
--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -197,6 +197,7 @@ class BotConfig(ConfigHelper):
         "light_device",
         "upload_path",
         "services",
+        "start_delay",
     ]
 
     def __init__(self, config: configparser.ConfigParser):
@@ -218,6 +219,7 @@ class BotConfig(ConfigHelper):
         self.upload_path: str = self._get_str("upload_path", default="")
         self.services: List[str] = self._get_list("services", default=["klipper", "moonraker"])
         self.log_parser: bool = self._get_boolean("log_parser", default=False)
+        self.start_delay: int = self._get_int("start_delay", default=1)
 
         host_parts = self.host.split(":")
         if len(host_parts) == 2 and host_parts[1].isdigit():

--- a/bot/main.py
+++ b/bot/main.py
@@ -1366,7 +1366,7 @@ if __name__ == "__main__":
 
     ws_helper = WebSocketHelper(configWrap, klippy, notifier, timelapse, a_scheduler, rotating_handler)
 
-    bot_updater.job_queue.run_once(start_scheduler, 1)
+    bot_updater.job_queue.run_once(start_scheduler, configWrap.bot_config.start_delay)
     bot_updater.run_polling(allowed_updates=Update.ALL_TYPES)
 
     logger.info("Shutting down the bot")


### PR DESCRIPTION
I got a problem with tg bot in docker container on extra orange-pi host.
I did not get greeting message, also no timelapses and status messages. Status command sent only snapshot.
After startup I got error message ''appscheduler Run time of job start_scheduler <...> was missed by <...>.
Also I noticed that time between adding this job and other messages in log is more than 5 seconds.
Python-telegram-bot docs says that run_polling method starts its own scheduler and first job in queue is start_scheduler callback.
So core of problem is time of strating bot (in run_polling method) is more than delay in run_once call parameters.
