### PR TITLE
A different implementation of telegram threads usage.

### DIFF
--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -172,6 +172,7 @@ class SecretsConfig(ConfigHelper):
 
         self.token: str = self._get_str("bot_token", default="")
         self.chat_id: int = self._get_int("chat_id", default=0)
+        self.thread_id: int = self._get_int("thread_id", default=0)
         self.user: str = self._get_str("user", default="")
         self.passwd: str = self._get_str("password", default="")
         self.api_token: str = self._get_str("api_token", default="")
@@ -182,6 +183,7 @@ class BotConfig(ConfigHelper):
     _KNOWN_ITEMS = [
         "bot_token",
         "chat_id",
+        "thread_id",
         "user",
         "password",
         "api_token",

--- a/bot/main.py
+++ b/bot/main.py
@@ -69,6 +69,20 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
+def tg_kwargs():
+    if configWrap.secrets.thread_id:
+        return {"message_thread_id": configWrap.secrets.thread_id}
+    return {}
+
+def wrong_thread(update: Update) -> bool:
+    if not configWrap.secrets.thread_id:
+        return False
+    msg = update.effective_message
+    if not msg:
+        return True
+    return msg.message_thread_id != configWrap.secrets.thread_id
+    
+
 
 def handle_exception(exc_type, exc_value, exc_traceback):
     if issubclass(exc_type, KeyboardInterrupt):
@@ -130,6 +144,8 @@ async def echo_unknown(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def unknown_chat(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
+    if wrong_thread(update):
+      return
     if update.effective_chat is None:
         logger.warning("Undefined effective chat")
         return
@@ -149,14 +165,14 @@ async def unknown_chat(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
 async def status_no_confirm(effective_message: Message) -> None:
     if klippy.printing and not configWrap.notifications.group_only:
         notifier.update_status()
-        time.sleep(configWrap.camera.light_timeout + 1.5)
+        await asyncio.sleep(configWrap.camera.light_timeout + 1.5)
         await effective_message.delete()
     else:
         mess = await klippy.get_status()
         if cameraWrap.enabled:
             loop_loc = asyncio.get_running_loop()
             with await loop_loc.run_in_executor(executors_pool, cameraWrap.take_photo) as bio:
-                await effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.UPLOAD_PHOTO)
+                await effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.UPLOAD_PHOTO, **tg_kwargs(),)
                 await effective_message.reply_photo(
                     photo=bio,
                     caption=mess,
@@ -165,7 +181,7 @@ async def status_no_confirm(effective_message: Message) -> None:
                 )
                 bio.close()
         else:
-            await effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING)
+            await effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING, **tg_kwargs(),)
             await effective_message.reply_text(
                 mess,
                 parse_mode=ParseMode.HTML,
@@ -175,6 +191,8 @@ async def status_no_confirm(effective_message: Message) -> None:
 
 
 async def status(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
+    if wrong_thread(update):
+            return
     if update.effective_message is None or update.effective_message.get_bot() is None:
         logger.warning("Undefined effective message or bot")
         return
@@ -189,7 +207,7 @@ async def check_unfinished_lapses(bot: telegram.Bot):
     files = cameraWrap.detect_unfinished_lapses()
     if not files:
         return
-    await bot.send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING)
+    await bot.send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING, **tg_kwargs(),)
     files_keys: List[List[InlineKeyboardButton]] = list(
         map(
             lambda el: [
@@ -222,6 +240,7 @@ async def check_unfinished_lapses(bot: telegram.Bot):
         text="Unfinished timelapses found\nBuild unfinished timelapse?",
         reply_markup=InlineKeyboardMarkup(files_keys),
         disable_notification=notifier.silent_status,
+        **tg_kwargs(),
     )
 
 
@@ -230,6 +249,8 @@ async def get_ip_no_confirm(effective_message: Message) -> None:
 
 
 async def get_ip(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
+    if wrong_thread(update):
+        return
     if update.effective_message is None or update.effective_message.get_bot() is None:
         logger.warning("Undefined effective message or bot")
         return
@@ -249,7 +270,7 @@ async def get_video_no_confirm(effective_message: Message) -> None:
             disable_notification=notifier.silent_commands,
             quote=True,
         )
-        await effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.RECORD_VIDEO)
+        await effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.RECORD_VIDEO, **tg_kwargs(),)
 
         loop_loc = asyncio.get_running_loop()
         (video_bio, thumb_bio, width, height) = await loop_loc.run_in_executor(executors_pool, cameraWrap.take_video)
@@ -275,6 +296,8 @@ async def get_video_no_confirm(effective_message: Message) -> None:
 
 
 async def get_video(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
+    if wrong_thread(update):
+        return
     if update.effective_message is None or update.effective_message.get_bot() is None:
         logger.warning("Undefined effective message or bot")
         return
@@ -306,7 +329,7 @@ async def command_confirm_message(update: Update, text: str, callback_mess: str)
         logger.warning("Undefined effective message or bot")
         return
 
-    await update.effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING)
+    await update.effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING, **tg_kwargs(),)
     await update.effective_message.reply_text(
         text,
         reply_markup=confirm_keyboard(callback_mess),
@@ -320,7 +343,7 @@ async def command_confirm_message_ext(update: Update, command: str, confirm_text
         logger.warning("Undefined effective message or bot")
         return
 
-    await update.effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING)
+    await update.effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING, **tg_kwargs(),)
     if configWrap.telegram_ui.is_present_in_require_confirmation(command) or configWrap.telegram_ui.confirm_command():
         await update.effective_message.reply_text(
             confirm_text,
@@ -459,7 +482,7 @@ async def send_logs_no_confirm(effective_message: Message) -> None:
 
     if logs_list:
         await resp_message.edit_text("Uploading logs")
-        await effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.UPLOAD_DOCUMENT)
+        await effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.UPLOAD_DOCUMENT, **tg_kwargs(),)
         await effective_message.reply_media_group(logs_list, disable_notification=notifier.silent_commands, quote=True, write_timeout=120)
         await resp_message.edit_text(text=f"{await klippy.get_versions_info()}\nUpload logs to analyzer /logs_upload")
     else:
@@ -498,7 +521,7 @@ async def upload_logs_no_confirm(effective_message: Message) -> None:
                 tar.add(Path(f"{configWrap.bot_config.log_path}/{file}"), arcname=file)
 
     await resp_message.edit_text("Uploading logs to parser")
-    await effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.UPLOAD_DOCUMENT)
+    await effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.UPLOAD_DOCUMENT, **tg_kwargs(),)
 
     with open(f"{configWrap.bot_config.log_path}/logs.tar.xz", "rb") as log_archive_ojb:
         resp = httpx.post(url="https://coderus.openrepos.net/klipper_logs", files={"tarfile": log_archive_ojb}, follow_redirects=False, timeout=25)
@@ -530,7 +553,7 @@ async def restart_bot() -> None:
 
 
 async def power_toggle_no_confirm(effective_message: Message) -> None:
-    await effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING)
+    await effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING, **tg_kwargs(),)
     if psu_power_device:
         await effective_message.reply_text(
             "Power " + "Off" if psu_power_device.device_state else "On" + " printer?",
@@ -547,6 +570,8 @@ async def power_toggle_no_confirm(effective_message: Message) -> None:
 
 
 async def power_toggle(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
+    if wrong_thread(update):
+        return
     if update.effective_message is None or update.effective_message.get_bot() is None:
         logger.warning("Undefined effective message or bot")
         return
@@ -577,6 +602,8 @@ async def light_toggle_no_confirm(effective_message: Message) -> None:
 
 
 async def light_toggle(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
+    if wrong_thread(update):
+        return
     if update.effective_message is None:
         logger.warning("Undefined effective message")
         return
@@ -588,6 +615,8 @@ async def light_toggle(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def button_lapse_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if wrong_thread(update):
+      return
     if update.effective_message is None or update.effective_message.get_bot() is None or update.callback_query is None:
         logger.warning("Undefined effective message or bot or query")
         return
@@ -610,8 +639,9 @@ async def button_lapse_handler(update: Update, context: ContextTypes.DEFAULT_TYP
         chat_id=configWrap.secrets.chat_id,
         text=f"Starting time-lapse assembly for {lapse_name}",
         disable_notification=notifier.silent_commands,
+        **tg_kwargs(),
     )
-    await context.bot.send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.RECORD_VIDEO)
+    await context.bot.send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.RECORD_VIDEO, **tg_kwargs(),)
     await timelapse.upload_timelapse(lapse_name, info_mess)
     info_mess = None  # type: ignore
     await query.delete_message()
@@ -619,6 +649,8 @@ async def button_lapse_handler(update: Update, context: ContextTypes.DEFAULT_TYP
 
 
 async def print_file_dialog_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if wrong_thread(update):
+      return
     if update.effective_message is None or update.effective_message.get_bot() is None or update.callback_query is None:
         logger.warning("Undefined effective message or bot or query")
         return
@@ -661,6 +693,8 @@ async def print_file_dialog_handler(update: Update, context: ContextTypes.DEFAUL
 
 
 async def button_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if wrong_thread(update):
+      return
     if update.effective_message is None or update.effective_message.get_bot() is None or update.callback_query is None:
         logger.warning("Undefined effective message or bot or query")
         return
@@ -681,7 +715,7 @@ async def button_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         logger.error("Undefined callback_query.data for %s", query.to_json())
         return
 
-    await context.bot.send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING)
+    await context.bot.send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING, **tg_kwargs(),)
 
     await query.answer()
     if query.data == "do_nothing":
@@ -691,7 +725,7 @@ async def button_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
                 update.effective_message.reply_to_message.message_id,
             )
     elif query.data == "cleanup_timelapse_unfinished":
-        await context.bot.send_message(chat_id=configWrap.secrets.chat_id, text="Removing unfinished timelapses data")
+        await context.bot.send_message(chat_id=configWrap.secrets.chat_id, text="Removing unfinished timelapses data", **tg_kwargs(),)
         cameraWrap.cleanup_unfinished_lapses()
     elif "gcode:" in query.data:
         await ws_helper.execute_ws_gcode_script(query.data.replace("gcode:", ""))
@@ -806,7 +840,7 @@ async def button_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
 
 async def get_gcode_files_no_confirm(effective_message: Message) -> None:
-    await effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING)
+    await effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING, **tg_kwargs(),)
     await effective_message.reply_text(
         "Gcode files to print:",
         reply_markup=await gcode_files_keyboard(),
@@ -816,6 +850,8 @@ async def get_gcode_files_no_confirm(effective_message: Message) -> None:
 
 
 async def get_gcode_files(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
+    if wrong_thread(update):
+        return
     if update.effective_message is None or update.effective_message.get_bot() is None:
         logger.warning("Undefined effective message or bot")
         return
@@ -878,7 +914,7 @@ async def services_keyboard_no_confirm(effective_message: Message) -> None:
     services = configWrap.bot_config.services
     service_keys: List[List[InlineKeyboardButton]] = list(map(create_service_button, services))
 
-    await effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING)
+    await effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING, **tg_kwargs(),)
     await effective_message.reply_text(
         "Services to operate:",
         reply_markup=InlineKeyboardMarkup(service_keys),
@@ -888,6 +924,8 @@ async def services_keyboard_no_confirm(effective_message: Message) -> None:
 
 
 async def services_keyboard(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
+    if wrong_thread(update):
+        return
     if update.effective_message is None or update.effective_message.get_bot() is None:
         logger.warning("Undefined effective message or bot")
         return
@@ -899,6 +937,8 @@ async def services_keyboard(update: Update, _: ContextTypes.DEFAULT_TYPE) -> Non
 
 
 async def exec_gcode(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
+    if wrong_thread(update):
+        return
     # maybe use context.args
     if update.effective_message is None or update.effective_message.text is None:
         logger.warning("Undefined effective message or text")
@@ -915,7 +955,7 @@ async def exec_gcode(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def get_macros_no_confirm(effective_message: Message) -> None:
-    await effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING)
+    await effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.TYPING, **tg_kwargs(),)
     files_keys: List[List[InlineKeyboardButton]] = list(
         map(
             lambda el: [
@@ -937,6 +977,8 @@ async def get_macros_no_confirm(effective_message: Message) -> None:
 
 
 async def get_macros(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
+    if wrong_thread(update):
+        return
     if update.effective_message is None or update.effective_message.get_bot() is None:
         logger.warning("Undefined effective message or bot")
         return
@@ -948,6 +990,8 @@ async def get_macros(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def macros_handler(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
+    if wrong_thread(update):
+      return
     if not update.effective_message or update.effective_message.text is None:
         logger.warning("Undefined effective message or update.effective_message.text")
         return
@@ -977,7 +1021,7 @@ async def upload_file(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
         logger.warning("Undefined effective message or bot")
         return
 
-    await update.effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.UPLOAD_DOCUMENT)
+    await update.effective_message.get_bot().send_chat_action(chat_id=configWrap.secrets.chat_id, action=ChatAction.UPLOAD_DOCUMENT, **tg_kwargs(),)
     doc = update.effective_message.document
     if doc is None or doc.file_name is None:
         await update.effective_message.reply_text(
@@ -1155,6 +1199,8 @@ async def help_command_no_confirm(effective_message: Message) -> None:
 
 
 async def help_command(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
+    if wrong_thread(update):
+        return
     if update.effective_message is None:
         logger.warning("Undefined effective message")
         return
@@ -1207,6 +1253,7 @@ async def greeting_message(bot: telegram.Bot) -> None:
             parse_mode=ParseMode.HTML,
             reply_markup=ReplyKeyboardMarkup(create_keyboard(), resize_keyboard=True),
             disable_notification=notifier.silent_status,
+            **tg_kwargs(),
         )
 
     await bot.set_my_commands(commands=prepare_commands_list(await klippy.get_macros_force(), configWrap.telegram_ui.include_macros_in_command_list))


### PR DESCRIPTION
I found current implementation useless for my case. Our farm has a group with threads, one per printer. My implementation allows everyone who has access to thread to use each printer, instead of just posting status. I apologize in advance if those changes were unnecessary and current version allows following such way as I've described.
It uses "thread_id:" in the [bot] section
<img width="1305" height="848" alt="image" src="https://github.com/user-attachments/assets/c7046080-6a50-435d-8971-57d9b51cba6b" />
