### PR TITLE
fix set_printing_filename crash on failed metadata response

### DIFF
--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -271,12 +271,12 @@ class Klippy:
             self._reset_file_info()
             return
 
+        self._printing_filename = new_value
         response = await self.make_request("GET", f"/server/files/metadata?filename={urllib.parse.quote(new_value)}")
-        # Todo: add response status check!
         if not response.is_success:
             logger.warning("bad response for file request %s", response.status_code)
+            return
         resp = orjson.loads(response.text)["result"]
-        self._printing_filename = new_value
         self.file_estimated_time = resp["estimated_time"] if resp.get("estimated_time") else 0.0
         self.file_print_start_time = resp["print_start_time"] if resp.get("print_start_time") else time.time()
         self.filament_total = resp["filament_total"] if "filament_total" in resp else 0.0

--- a/bot/main.py
+++ b/bot/main.py
@@ -238,7 +238,7 @@ async def get_video_no_confirm(effective_message: Message) -> None:
         await effective_message.get_bot().send_chat_action(chat_id=config_wrap.secrets.chat_id, action=ChatAction.RECORD_VIDEO)
 
         loop_loc = asyncio.get_running_loop()
-        (video_bio, thumb_bio, width, height) = await loop_loc.run_in_executor(executors_pool, cameraWrap.take_video)
+        video_bio, thumb_bio, width, height = await loop_loc.run_in_executor(executors_pool, cameraWrap.take_video)
         await info_reply.edit_text(text="Uploading video")
         max_upload_file_size: int = config_wrap.bot_config.max_upload_file_size
         if video_bio.getbuffer().nbytes > max_upload_file_size * 1024 * 1024:

--- a/tests/klippy_test.py
+++ b/tests/klippy_test.py
@@ -69,3 +69,16 @@ async def test_jwt_refresh_updates_headers_on_retry(mock_klippy):
 
     await mock_klippy.make_request("GET", "/api/test")
     assert retry_headers.get("Authorization") == "Bearer new_token"
+
+
+@pytest.mark.asyncio
+async def test_set_printing_filename_handles_bad_response(mock_klippy):
+    error_response = httpx.Response(
+        status_code=404,
+        text='{"error": {"message": "File not found"}}',
+        request=httpx.Request("GET", "http://localhost:7125/server/files/metadata"),
+    )
+    mock_klippy.make_request = AsyncMock(return_value=error_response)
+
+    await mock_klippy.set_printing_filename("nonexistent_file.gcode")
+    assert mock_klippy.printing_filename == "nonexistent_file.gcode"


### PR DESCRIPTION
If `/server/files/metadata?filename=<new_value>` returns 404, just set `self._printing_filename` and return, do not parse error response which won't have expected keys.

Fixes #392 