### PR TITLE
fix JWT token refresh retry using stale headers

### DIFF
--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -345,13 +345,12 @@ class Klippy:
         except httpx.HTTPError as err:
             logger.error("Failed to refresh token: %s", err)
 
-    async def make_request(self, method, url_path, json=None, headers=None, files=None, timeout=30) -> httpx.Response:
-        _headers = headers if headers else self._headers
-        res = await self._client.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=_headers, files=files, timeout=timeout)
+    async def make_request(self, method, url_path, json=None, files=None, timeout=30) -> httpx.Response:
+        res = await self._client.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=self._headers, files=files, timeout=timeout)
         if res.status_code == 401:  # Unauthorized
             logger.debug("JWT token expired, refreshing...")
             await self._refresh_moonraker_token()
-            res = await self._client.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=_headers, files=files, timeout=timeout)
+            res = await self._client.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=self._headers, files=files, timeout=timeout)
 
         try:
             res.raise_for_status()
@@ -360,13 +359,12 @@ class Klippy:
 
         return res
 
-    def make_request_sync(self, method, url_path, json=None, headers=None, files=None, timeout=30) -> httpx.Response:
-        _headers = headers if headers else self._headers
-        res = self._client_sync.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=_headers, files=files, timeout=timeout)
+    def make_request_sync(self, method, url_path, json=None, files=None, timeout=30) -> httpx.Response:
+        res = self._client_sync.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=self._headers, files=files, timeout=timeout)
         if res.status_code == 401:  # Unauthorized
             logger.debug("JWT token expired, refreshing...")
             self._refresh_moonraker_token_sync()
-            res = self._client_sync.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=_headers, files=files, timeout=timeout)
+            res = self._client_sync.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=self._headers, files=files, timeout=timeout)
 
         try:
             res.raise_for_status()

--- a/scripts/requirements.dev.txt
+++ b/scripts/requirements.dev.txt
@@ -12,6 +12,7 @@ pre-commit==4.5.1 ; python_version>='3.9'
 psutil==7.2.2
 pylint==4.0.4
 pytest==9.0.2
+pytest-asyncio==1.3.0
 types-aiofiles==25.1.0.20251011
 types-cachetools==6.2.0.20251022
 types-emoji==2.1.0.3

--- a/tests/klippy_test.py
+++ b/tests/klippy_test.py
@@ -1,3 +1,8 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
 from bot.klippy import Klippy  # type: ignore
 
 test_sensors = {
@@ -12,3 +17,55 @@ def test_sensor_message():
     temp_sensor_message = Klippy._sensor_message("temp", test_sensors["temp"])
     fan_message = Klippy._sensor_message("fan", test_sensors["fan"])
     assert heater_message == "♨️ Heater: 155 °C ➡️ 255 °C 🔥" and fan_message == "🌪️ Fan: 155 °C ➡️ 255 °C 75% 2550 RPM" and temp_sensor_message == "🌡️ Temp: 155 °C"
+
+
+@pytest.fixture
+def mock_klippy():
+    config = MagicMock()
+    config.bot_config.ssl = False
+    config.bot_config.host = "localhost"
+    config.bot_config.port = 7125
+    config.bot_config.ssl_verify = True
+    config.bot_config.debug = False
+    config.telegram_ui.hidden_macros = []
+    config.telegram_ui.show_private_macros = False
+    config.telegram_ui.eta_source = "slicer"
+    config.status_message_content.content = []
+    config.status_message_content.sensors = []
+    config.status_message_content.heaters = []
+    config.status_message_content.fans = []
+    config.status_message_content.moonraker_devices = []
+    config.secrets.user = ""
+    config.secrets.passwd = ""
+    config.secrets.api_token = ""
+
+    klippy = Klippy(config, None)
+    return klippy
+
+
+@pytest.mark.asyncio
+async def test_jwt_refresh_updates_headers_on_retry(mock_klippy):
+    mock_klippy._jwt_token = "expired_token"
+    mock_klippy._refresh_token = "valid_refresh"
+
+    retry_headers = {}
+
+    async def fake_refresh():
+        mock_klippy._jwt_token = "new_token"
+
+    call_count = 0
+
+    async def fake_request(method, url, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return httpx.Response(status_code=401, request=httpx.Request(method, url))
+        retry_headers.update(kwargs.get("headers", {}))
+        return httpx.Response(status_code=200, text='{"result":"ok"}', request=httpx.Request(method, url))
+
+    mock_klippy._client = MagicMock()
+    mock_klippy._client.request = AsyncMock(side_effect=fake_request)
+    mock_klippy._refresh_moonraker_token = AsyncMock(side_effect=fake_refresh)
+
+    await mock_klippy.make_request("GET", "/api/test")
+    assert retry_headers.get("Authorization") == "Bearer new_token"


### PR DESCRIPTION
Fix bug when JWT token can't refresh properly.

Local variable `_headers` holds reference to old headers which is are generated by `self._headers` property from JWT token. After `self._refresh_moonraker_token()` updates `self._jwt_token`, `headers` still uses old one.

Solution: always use `self._headers`.

`headers` argument in `make_request` is never actually used.