### PR TITLE
skip docker job on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,7 @@ jobs:
 
   docker:
     needs: pre-commit
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     steps:
       -


### PR DESCRIPTION
Docker login fails on PRs from forks because repository secrets are not available. The job is only needed on push to master/development.