### PR TITLE
Fix height notification for fractional Z positions

### DIFF
--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -56,7 +56,8 @@ class Notifier:
         self._use_status_update_button: bool = config.telegram_ui.status_update_button
         self._message_parts: List[str] = config.status_message_content.content
 
-        self._last_height: int = 0
+        self._last_height: float = 0
+        self._below_threshold: bool = False
         self._last_percent: int = 0
         self._last_m117_status: str = ""
         self._last_tgnotify_status: str = ""
@@ -303,6 +304,7 @@ class Notifier:
     async def reset_notifications(self) -> None:
         self._last_percent = 0
         self._last_height = 0
+        self._below_threshold = False
         self._klippy.printing_duration = 0
         self._last_m117_status = ""
         self._last_tgnotify_status = ""
@@ -347,7 +349,7 @@ class Notifier:
             replace_existing=False,
         )
 
-    def schedule_notification(self, progress: int = 0, position_z: int = 0) -> None:
+    def schedule_notification(self, progress: int = 0, position_z: float = 0) -> None:
         if not self._klippy.printing or self._klippy.printing_duration <= 0.0 or (self._height == 0 and self._percent == 0):
             return
 
@@ -360,10 +362,19 @@ class Notifier:
                 notify = True
 
         if position_z != 0 and self._height != 0:
+            # Z dropped significantly — reset for sequential objects or print restart
             if position_z < self._last_height - self._height:
-                self._last_height = position_z
-            if position_z % self._height == 0 and position_z > self._last_height:
-                self._last_height = position_z
+                self._last_height = round((position_z // self._height) * self._height, 2)
+                self._below_threshold = True
+            # Only fire when Z rises through threshold within proximity.
+            # This rejects wild Z jumps during start gcode, travel moves, etc.
+            next_threshold = self._last_height + self._height
+            if position_z < next_threshold:
+                self._below_threshold = True
+            elif self._below_threshold and position_z < next_threshold + 1.0:
+                self._last_height = round((position_z // self._height) * self._height, 2)
+                self._below_threshold = False
+                logger.info("Height notification at Z=%.2f (threshold %.2f)", position_z, next_threshold)
                 notify = True
 
         if notify:

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -207,7 +207,7 @@ class WebSocketHelper:
         if "gcode_move" in message_params_loc and "gcode_position" in message_params_loc["gcode_move"]:
             position_z = message_params_loc["gcode_move"]["gcode_position"][2]
             self._klippy.printing_height = position_z
-            self._notifier.schedule_notification(position_z=int(position_z))
+            self._notifier.schedule_notification(position_z=round(position_z, 2))
             self._timelapse.take_lapse_photo(position_z)
 
         if "virtual_sdcard" in message_params_loc and "progress" in message_params_loc["virtual_sdcard"]:

--- a/tests/notifications_test.py
+++ b/tests/notifications_test.py
@@ -1,0 +1,155 @@
+from unittest.mock import MagicMock
+
+from bot.notifications import Notifier  # type: ignore
+
+
+def make_notifier(height=5.0, percent=0):
+    config = MagicMock()
+    config.secrets.chat_id = 123
+    config.notifications.enabled = True
+    config.notifications.percent = percent
+    config.notifications.height = height
+    config.notifications.interval = 0
+    config.notifications.notify_groups = []
+    config.notifications.group_only = False
+    config.bot_config.max_upload_file_size = 50
+    config.bot_config.debug = False
+    config.telegram_ui.progress_update_message = True
+    config.telegram_ui.silent_progress = False
+    config.telegram_ui.silent_commands = False
+    config.telegram_ui.silent_status = False
+    config.telegram_ui.pin_status_single_message = False
+    config.telegram_ui.status_message_m117_update = False
+    config.telegram_ui.status_update_button = False
+    config.status_message_content.content = []
+
+    klippy = MagicMock()
+    klippy.printing = True
+    klippy.printing_duration = 100.0
+
+    return Notifier(config, MagicMock(), klippy, MagicMock(), MagicMock(), None)
+
+
+def test_height_notification_triggers_at_threshold():
+    n = make_notifier(height=2.5)
+    n._schedule_notification = MagicMock()
+
+    # must see Z below threshold before firing
+    n.schedule_notification(position_z=0.2)
+    n.schedule_notification(position_z=2.5)
+    assert n._schedule_notification.call_count == 1
+
+    n.schedule_notification(position_z=3.0)
+    n.schedule_notification(position_z=5.0)
+    assert n._schedule_notification.call_count == 2
+
+    n.schedule_notification(position_z=6.0)
+    n.schedule_notification(position_z=7.5)
+    assert n._schedule_notification.call_count == 3
+
+    # below next threshold — no new notification
+    n.schedule_notification(position_z=9.0)
+    assert n._schedule_notification.call_count == 3
+
+    # same height again — no duplicate
+    n.schedule_notification(position_z=7.5)
+    assert n._schedule_notification.call_count == 3
+
+
+def test_height_notification_with_real_layers():
+    """With 0.2mm layers Z never lands exactly on 2.5 — must still trigger."""
+    n = make_notifier(height=2.5)
+    n._schedule_notification = MagicMock()
+    layer = 0.2
+
+    # layers up to 2.4 — below first threshold
+    z = layer
+    while z < 2.5:
+        n.schedule_notification(position_z=round(z, 2))
+        z += layer
+    assert n._schedule_notification.call_count == 0
+
+    # 2.6 crosses 2.5
+    n.schedule_notification(position_z=2.6)
+    assert n._schedule_notification.call_count == 1
+    assert n._last_height == 2.5  # snapped, not drifted to 2.6
+
+    # continue up to 4.8 — below 5.0 threshold
+    z = 2.8
+    while z < 5.0:
+        n.schedule_notification(position_z=round(z, 2))
+        z += layer
+    assert n._schedule_notification.call_count == 1
+
+    n.schedule_notification(position_z=5.0)
+    assert n._schedule_notification.call_count == 2
+
+
+def test_height_notification_rejects_wild_z_jumps():
+    """Z far above threshold (start gcode, travel moves) should not fire."""
+    n = make_notifier(height=2.5)
+    n._schedule_notification = MagicMock()
+
+    # purge at low Z then Z jumps high — too far from threshold
+    n.schedule_notification(position_z=0.3)
+    n.schedule_notification(position_z=4.5)
+    assert n._schedule_notification.call_count == 0
+
+    # Z drops to first layer, rises normally
+    n.schedule_notification(position_z=0.2)
+    n.schedule_notification(position_z=2.6)
+    assert n._schedule_notification.call_count == 1
+
+    # wild Z jump mid-print — too far from next threshold (5.0)
+    n.schedule_notification(position_z=0.4)
+    n.schedule_notification(position_z=50.6)
+    assert n._schedule_notification.call_count == 1
+
+    # back to normal layers, fires at 5.0
+    n.schedule_notification(position_z=3.0)
+    n.schedule_notification(position_z=5.0)
+    assert n._schedule_notification.call_count == 2
+
+
+def test_height_notification_sequential_objects():
+    """Z drops back to first layer between objects — should restart notifications."""
+    n = make_notifier(height=2.5)
+    n._schedule_notification = MagicMock()
+
+    layer = 0.2
+    obj_height = 10.0
+
+    # first object
+    z = layer
+    while z <= obj_height:
+        n.schedule_notification(position_z=round(z, 2))
+        z += layer
+    # fired at 2.5, 5.0, 7.5, 10.0
+    assert n._schedule_notification.call_count == 4
+
+    # Z drops to first layer for second object
+    n.schedule_notification(position_z=layer)
+
+    # notifications restart — climb just below first threshold
+    z = layer
+    while z < 2.5:
+        n.schedule_notification(position_z=round(z, 2))
+        z += layer
+    assert n._schedule_notification.call_count == 4  # no new
+
+    n.schedule_notification(position_z=2.6)
+    assert n._schedule_notification.call_count == 5
+
+
+def test_height_notification_guards():
+    n = make_notifier(height=5)
+    n._schedule_notification = MagicMock()
+
+    n._klippy.printing = False
+    n.schedule_notification(position_z=5.0)
+    assert n._schedule_notification.call_count == 0
+
+    n._klippy.printing = True
+    n._klippy.printing_duration = 0.0
+    n.schedule_notification(position_z=5.0)
+    assert n._schedule_notification.call_count == 0


### PR DESCRIPTION
`int(position_z)` in `websocket_helper` truncated Z values, so fractional height intervals (e.g. `height=2.5`) only triggered at integer multiples (5, 10, ...) and skipped the rest.

## Changes
- Use `round(position_z, 2)` instead of `int(position_z)`. E.g. this works for updating progress on each 0.15mm layer.
- Detect threshold crossing instead of exact modulo match. This handles Z that doesn't land exactly on multiples on `height`
- Reject wild Z jumps during start gcode / travel moves (use proximity check)
- Reset height tracking when Z drops (e.g. for printing sequential objects)
- Add unit tests

## Real test with 20mm tall print and `height=2.5`

```
2026-03-08 17:17:20,054 - notifications - INFO - notifications.py:377 - Height notification at Z=2.60 (threshold 2.50)
2026-03-08 17:19:12,810 - notifications - INFO - notifications.py:377 - Height notification at Z=5.00 (threshold 5.00)
2026-03-08 17:21:09,836 - notifications - INFO - notifications.py:377 - Height notification at Z=7.60 (threshold 7.50)
2026-03-08 17:23:10,874 - notifications - INFO - notifications.py:377 - Height notification at Z=10.20 (threshold 10.00)
2026-03-08 17:25:04,146 - notifications - INFO - notifications.py:377 - Height notification at Z=12.60 (threshold 12.50)
2026-03-08 17:27:16,208 - notifications - INFO - notifications.py:377 - Height notification at Z=15.10 (threshold 15.00)
2026-03-08 17:29:25,782 - notifications - INFO - notifications.py:377 - Height notification at Z=17.80 (threshold 17.50)
2026-03-08 17:31:31,322 - notifications - INFO - notifications.py:377 - Height notification at Z=20.00 (threshold 20.00)
```