### PR TITLE
Adjust print status messages based on print state

### DIFF
--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -1,6 +1,7 @@
 # Todo: class for printer states!
 import asyncio
 from datetime import datetime, timedelta
+from enum import Enum
 from io import BytesIO
 import logging
 import re
@@ -18,6 +19,23 @@ from PIL import Image
 from configuration import ConfigWrapper
 
 logger = logging.getLogger(__name__)
+
+
+class PrintState(Enum):
+    STANDBY = "standby"
+    START = "start"
+    PRINTING = "printing"
+    FINISH = "finish"
+    CANCELLED = "cancelled"
+    ERROR = "error"
+
+    @property
+    def is_start(self) -> bool:
+        return self == PrintState.START
+
+    @property
+    def is_finished(self) -> bool:
+        return self in (PrintState.FINISH, PrintState.CANCELLED, PrintState.ERROR)
 
 
 class PowerDevice:
@@ -121,6 +139,7 @@ class Klippy:
         self.printing_duration: float = 0.0
         self.printing_progress: float = 0.0
         self.printing_height: float = 0.0
+        self.file_object_height: float = 0.0
         self._printing_filename: str = ""
         self.file_estimated_time: float = 0.0
         self.file_print_start_time: float = 0.0
@@ -251,6 +270,7 @@ class Klippy:
         self.printing_duration = 0.0
         self.printing_progress = 0.0
         self.printing_height = 0.0
+        self.file_object_height = 0.0
         self._printing_filename = ""
         self.file_estimated_time = 0.0
         self.file_print_start_time = 0.0
@@ -286,6 +306,7 @@ class Klippy:
         self.file_print_start_time = resp["print_start_time"] if resp.get("print_start_time") else time.time()
         self.filament_total = resp["filament_total"] if "filament_total" in resp else 0.0
         self.filament_weight = resp["filament_weight_total"] if "filament_weight_total" in resp else 0.0
+        self.file_object_height = resp["object_height"] if resp.get("object_height") else 0.0
 
         if "thumbnails" in resp and "filename" in resp:
             thumb = max(resp["thumbnails"], key=lambda el: el["size"])
@@ -504,35 +525,63 @@ class Klippy:
         img.close()
         return message, bio
 
-    async def get_file_info(self, message: str = "") -> Tuple[str, BytesIO]:
-        message = self.get_print_stats(message)
+    async def get_file_info(self, state: PrintState = PrintState.PRINTING) -> Tuple[str, BytesIO]:
+        message = self.get_print_stats(state=state)
         return await self._populate_with_thumb(self._thumbnail_path, message)
 
-    def _get_printing_file_info(self, message_pre: str = "") -> str:
-        message = f"Printing: {self.printing_filename} \n" if not message_pre else f"{message_pre}: {self.printing_filename} \n"
+    _STATE_TITLES = {
+        PrintState.START: "Printer started printing",
+        PrintState.PRINTING: "Printing",
+        PrintState.FINISH: "Finished printing",
+        PrintState.CANCELLED: "Cancelled printing",
+        PrintState.ERROR: "Printing was interrupted with an error",
+    }
+
+    def _get_printing_file_info(self, state: PrintState = PrintState.PRINTING) -> str:
+        result = f"<b>{self._STATE_TITLES[state]}: {self.printing_filename}</b>\n"
         if "progress" in self._message_parts:
-            message += f"Progress {round(self.printing_progress * 100, 0)}%"
+            result += f"Progress {int(self.printing_progress * 100)}%"
         if "height" in self._message_parts:
-            message += f", height: {round(self.printing_height, 2)}mm\n" if self.printing_height > 0.0 else "\n"
+            show_current_height = state == PrintState.PRINTING
+            if show_current_height and self.printing_height > 0.0 and self.file_object_height > 0.0:
+                result += f", height: {round(self.printing_height, 2)} / {round(self.file_object_height, 2)}mm\n"
+            elif self.file_object_height > 0.0:
+                result += f", print height: {round(self.file_object_height, 2)}mm\n"
+            elif show_current_height and self.printing_height > 0.0:
+                result += f", height: {round(self.printing_height, 2)}mm\n"
+            else:
+                result += "\n"
         if self.filament_total > 0.0:
             if "filament_length" in self._message_parts:
-                message += f"Filament: {round(self.filament_used / 1000, 2)}m / {round(self.filament_total / 1000, 2)}m"
+                if state.is_start:
+                    result += f"Filament: {round(self.filament_total / 1000, 2)}m"
+                elif state.is_finished:
+                    result += f"Filament used: {round(self.filament_used / 1000, 2)}m"
+                else:
+                    result += f"Filament: {round(self.filament_used / 1000, 2)}m / {round(self.filament_total / 1000, 2)}m"
             if self.filament_weight > 0.0 and "filament_weight" in self._message_parts:
-                message += f", weight: {round(self._filament_weight_used(), 2)}/{self.filament_weight}g"
-            message += "\n"
-        if "print_duration" in self._message_parts:
-            message += f"Printing for {timedelta(seconds=round(self.printing_duration))}\n"
+                if state.is_start:
+                    result += f", weight: {self.filament_weight}g"
+                elif state.is_finished:
+                    result += f", weight: {round(self._filament_weight_used(), 2)}g"
+                else:
+                    result += f", weight: {round(self._filament_weight_used(), 2)} / {self.filament_weight}g"
+            result += "\n"
+        if "print_duration" in self._message_parts and not state.is_start:
+            duration_prefix = "Printed for" if state.is_finished else "Printing for"
+            result += f"{duration_prefix} {timedelta(seconds=round(self.printing_duration))}\n"
 
-        eta = self._get_eta()
-        if "eta" in self._message_parts:
-            message += f"Estimated time left: {eta}\n"
-        if "finish_time" in self._message_parts:
-            message += f"Finish at {datetime.now() + eta:%Y-%m-%d %H:%M}\n"
+        if state in (PrintState.START, PrintState.PRINTING):
+            eta = self._get_eta()
+            if "eta" in self._message_parts:
+                result += f"Estimated time left: {eta}\n"
+            if "finish_time" in self._message_parts:
+                result += f"Finish at {datetime.now() + eta:%Y-%m-%d %H:%M}\n"
 
-        return message
+        return result
 
-    def get_print_stats(self, message_pre: str = "") -> str:
-        return self._get_printing_file_info(message_pre) + self._get_sensors_message() + self._get_power_devices_mess()
+    def get_print_stats(self, state: PrintState = PrintState.PRINTING) -> str:
+        return self._get_printing_file_info(state=state) + self._get_sensors_message() + self._get_power_devices_mess()
 
     async def get_status(self) -> str:
         try:

--- a/bot/main.py
+++ b/bot/main.py
@@ -47,7 +47,7 @@ from telegram.ext import Application, CallbackContext, CallbackQueryHandler, Com
 
 from camera import Camera, FFmpegCamera, MjpegCamera, RawStreamCamera
 from configuration import ConfigWrapper
-from klippy import Klippy, PowerDevice
+from klippy import Klippy, PowerDevice, PrintState
 from notifications import Notifier
 from telegram_helper import TelegramMessageRepr
 from timelapse import Timelapse
@@ -167,7 +167,7 @@ async def status_no_confirm(effective_message: Message) -> None:
         notifier.update_status()
     else:
         text = await klippy.get_status()
-        message = TelegramMessageRepr(text, parse_mode=ParseMode.HTML, silent=notifier.silent_commands, reply_markup=notifier.get_status_keyboard())
+        message = TelegramMessageRepr(text, parse_mode=ParseMode.HTML, silent=notifier.silent_commands, reply_markup=notifier.get_status_keyboard(state=PrintState.STANDBY))
         if camera_wrap.enabled:
             loop_loc = asyncio.get_running_loop()
             with await loop_loc.run_in_executor(executors_pool, camera_wrap.take_photo) as bio:

--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -10,12 +10,12 @@ from typing import Dict, List, Optional, Tuple, Union
 import aiofiles
 from apscheduler.schedulers.base import BaseScheduler  # type: ignore
 from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup, InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo, Message
-from telegram.constants import ChatAction
+from telegram.constants import ChatAction, ParseMode
 from telegram.error import BadRequest
 
 from camera import Camera
 from configuration import ConfigWrapper
-from klippy import Klippy
+from klippy import Klippy, PrintState
 from telegram_helper import TelegramMessageRepr
 
 logger = logging.getLogger(__name__)
@@ -130,9 +130,9 @@ class Notifier:
             self._interval = new_value
             self._reschedule_notifier_timer()
 
-    def get_status_keyboard(self, finish: bool = False) -> Optional[InlineKeyboardMarkup]:
+    def get_status_keyboard(self, state: PrintState) -> Optional[InlineKeyboardMarkup]:
         inline_keyboard = None
-        if self._use_status_update_button and not finish:
+        if self._use_status_update_button and not state.is_finished:
             inline_keyboard = InlineKeyboardMarkup(
                 [
                     [
@@ -203,8 +203,8 @@ class Notifier:
 
             photo.close()
 
-    async def _notify(self, message: TelegramMessageRepr, group_only: bool = False, manual: bool = False, finish: bool = False) -> None:
-        if finish:
+    async def _notify(self, message: TelegramMessageRepr, group_only: bool = False, manual: bool = False, state: PrintState = PrintState.PRINTING) -> None:
+        if state.is_finished:
             await asyncio.sleep(5)
         try:
             if self._cam_wrap.enabled:
@@ -214,7 +214,7 @@ class Notifier:
         except Exception as ex:
             logger.error(ex, exc_info=True, stack_info=True)
         finally:
-            if finish:
+            if state.is_finished:
                 await self.reset_notifications()
 
     # manual notification methods
@@ -306,6 +306,7 @@ class Notifier:
         self._last_height = 0
         self._below_threshold = False
         self._klippy.printing_duration = 0
+        self._klippy.printing_height = 0.0
         self._last_m117_status = ""
         self._last_tgnotify_status = ""
 
@@ -325,8 +326,8 @@ class Notifier:
             finally:
                 self._bzz_mess_id = 0
 
-    def _schedule_notification(self, message: str = "", finish: bool = False) -> None:  # pylint: disable=W0613
-        mess = self._klippy.get_print_stats(message)
+    def _schedule_notification(self, state: PrintState = PrintState.PRINTING) -> None:
+        mess = self._klippy.get_print_stats(state=state)
         if self._last_m117_status and "m117_status" in self._message_parts:
             mess += self._last_m117_status + "\n"
         if self._last_tgnotify_status and "tgnotify_status" in self._message_parts:
@@ -337,12 +338,12 @@ class Notifier:
         tg_message = TelegramMessageRepr(
             text=mess,
             silent=self._silent_progress,
-            reply_markup=self.get_status_keyboard(finish=finish),
+            reply_markup=self.get_status_keyboard(state=state),
         )
 
         self._sched.add_job(
             self._notify,
-            kwargs={"message": tg_message, "group_only": self._group_only, "finish": finish},
+            kwargs={"message": tg_message, "group_only": self._group_only, "state": state},
             misfire_grace_time=180,
             coalesce=False,
             max_instances=6,
@@ -416,7 +417,7 @@ class Notifier:
 
     # Todo: refactor with TelegramMessageRepr class
     async def _send_print_start_info(self) -> None:
-        message, bio = await self._klippy.get_file_info("Printer started printing")
+        message, bio = await self._klippy.get_file_info(state=PrintState.START)
 
         if bio is not None:
             if not self._group_only:
@@ -424,7 +425,8 @@ class Notifier:
                     self._chat_id,
                     photo=bio,
                     caption=message,
-                    reply_markup=self.get_status_keyboard(),
+                    parse_mode=ParseMode.HTML,
+                    reply_markup=self.get_status_keyboard(state=PrintState.START),
                     disable_notification=self.silent_status,
                 )
                 self._status_message = status_message
@@ -436,18 +438,26 @@ class Notifier:
                     message_thread_id=message_thread_id,
                     photo=bio,
                     caption=message,
-                    reply_markup=self.get_status_keyboard(),
+                    parse_mode=ParseMode.HTML,
+                    reply_markup=self.get_status_keyboard(state=PrintState.START),
                     disable_notification=self.silent_status,
                 )
             bio.close()
         else:
             if not self._group_only:
-                status_message = await self._bot.send_message(chat_id=self._chat_id, text=message, reply_markup=self.get_status_keyboard(), disable_notification=self.silent_status)
+                status_message = await self._bot.send_message(
+                    chat_id=self._chat_id, text=message, parse_mode=ParseMode.HTML, reply_markup=self.get_status_keyboard(state=PrintState.START), disable_notification=self.silent_status
+                )
                 self._status_message = status_message
 
             for group_, message_thread_id in self._notify_groups:
                 self._groups_status_messages[group_] = await self._bot.send_message(
-                    chat_id=group_, message_thread_id=message_thread_id, text=message, reply_markup=self.get_status_keyboard(), disable_notification=self.silent_status
+                    chat_id=group_,
+                    message_thread_id=message_thread_id,
+                    text=message,
+                    parse_mode=ParseMode.HTML,
+                    reply_markup=self.get_status_keyboard(state=PrintState.START),
+                    disable_notification=self.silent_status,
                 )
 
         if self._pin_status_single_message and self._status_message is not None:
@@ -466,7 +476,7 @@ class Notifier:
         # Todo: reset something? or check if reset by setting new filename?
 
     async def _send_print_finish(self) -> None:
-        self._schedule_notification(message="Finished printing", finish=True)
+        self._schedule_notification(state=PrintState.FINISH)
 
     def send_print_finish(self) -> None:
         if self._enabled:
@@ -478,14 +488,14 @@ class Notifier:
                 replace_existing=True,
             )
 
-    async def _update_status_on_abort(self, message) -> None:
-        self._schedule_notification(message=message, finish=True)
+    async def _update_status_on_abort(self, state: PrintState) -> None:
+        self._schedule_notification(state=state)
 
-    def update_status_on_abort(self, message) -> None:
+    def update_status_on_abort(self, state: PrintState) -> None:
         if self._enabled:
             self._sched.add_job(
                 self._update_status_on_abort,
-                kwargs={"message": message},
+                kwargs={"state": state},
                 misfire_grace_time=None,
                 coalesce=False,
                 max_instances=1,

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -14,7 +14,7 @@ from websockets.asyncio.client import ClientConnection, connect
 from websockets.protocol import State
 
 from configuration import ConfigWrapper
-from klippy import Klippy
+from klippy import Klippy, PrintState
 from notifications import Notifier
 from timelapse import Timelapse
 
@@ -279,7 +279,7 @@ class WebSocketHelper:
             # Fixme: add finish printing method in notifier
             self._notifier.send_print_finish()
         elif state == "error":
-            self._notifier.update_status_on_abort(message="Printing was interrupted with an error")
+            self._notifier.update_status_on_abort(state=PrintState.ERROR)
             self._klippy.printing = False
             self._timelapse.is_running = False
             self._notifier.remove_notifier_timer()
@@ -297,7 +297,7 @@ class WebSocketHelper:
             # self._timelapse.send_timelapse()
             self._notifier.send_printer_status_notification(f"Printer state change: {print_stats_loc['state']} \n")
         elif state == "cancelled":
-            self._notifier.update_status_on_abort(message="Printing cancelled")
+            self._notifier.update_status_on_abort(state=PrintState.CANCELLED)
             self._klippy.paused = False
             self._klippy.printing = False
             self._timelapse.is_running = False

--- a/tests/klippy_test.py
+++ b/tests/klippy_test.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
-from bot.klippy import Klippy  # type: ignore
+from bot.klippy import Klippy, PrintState  # type: ignore
 
 test_sensors = {
     "heater": {"temperature": 155.345325234, "target": 255.343434, "power": 0.60},
@@ -82,3 +82,118 @@ async def test_set_printing_filename_handles_bad_response(mock_klippy):
 
     await mock_klippy.set_printing_filename("nonexistent_file.gcode")
     assert mock_klippy.printing_filename == "nonexistent_file.gcode"
+
+
+def test_progress_shows_current_and_object_height(mock_klippy):
+    mock_klippy._message_parts = ["progress", "height"]
+    mock_klippy._printing_filename = "test.gcode"
+    mock_klippy.printing_height = 5.2
+    mock_klippy.file_object_height = 19.6
+    msg = mock_klippy._get_printing_file_info()
+    assert "height: 5.2 / 19.6mm" in msg
+
+
+def test_start_shows_only_object_height(mock_klippy):
+    mock_klippy._message_parts = ["progress", "height"]
+    mock_klippy._printing_filename = "test.gcode"
+    mock_klippy.printing_height = 15.3
+    mock_klippy.file_object_height = 19.6
+    msg = mock_klippy._get_printing_file_info(state=PrintState.START)
+    assert "print height: 19.6mm" in msg
+    assert "15.3" not in msg
+
+
+def test_finish_shows_only_object_height(mock_klippy):
+    mock_klippy._message_parts = ["progress", "height"]
+    mock_klippy._printing_filename = "test.gcode"
+    mock_klippy.printing_height = 2.0
+    mock_klippy.file_object_height = 19.6
+    msg = mock_klippy._get_printing_file_info(state=PrintState.FINISH)
+    assert "print height: 19.6mm" in msg
+    assert "2.0" not in msg
+
+
+def test_height_fallback_without_object_height(mock_klippy):
+    mock_klippy._message_parts = ["progress", "height"]
+    mock_klippy._printing_filename = "test.gcode"
+    mock_klippy.printing_height = 5.2
+    mock_klippy.file_object_height = 0.0
+    msg = mock_klippy._get_printing_file_info()
+    assert "height: 5.2mm" in msg
+
+
+def test_no_height_when_both_zero(mock_klippy):
+    mock_klippy._message_parts = ["progress", "height"]
+    mock_klippy._printing_filename = "test.gcode"
+    mock_klippy.printing_height = 0.0
+    mock_klippy.file_object_height = 0.0
+    msg = mock_klippy._get_printing_file_info()
+    assert "height" not in msg
+
+
+def test_start_shows_only_total_filament(mock_klippy):
+    mock_klippy._message_parts = ["progress", "filament_length", "filament_weight"]
+    mock_klippy._printing_filename = "test.gcode"
+    mock_klippy.filament_total = 5000.0
+    mock_klippy.filament_used = 1200.0
+    mock_klippy.filament_weight = 15.0
+    msg = mock_klippy._get_printing_file_info(state=PrintState.START)
+    assert "Filament: 5.0m" in msg
+    assert "1.2m" not in msg
+    assert "weight: 15.0g" in msg
+    assert "/" not in msg.split("Filament:")[1]
+
+
+def test_finish_shows_only_used_filament(mock_klippy):
+    mock_klippy._message_parts = ["progress", "filament_length", "filament_weight"]
+    mock_klippy._printing_filename = "test.gcode"
+    mock_klippy.filament_total = 5000.0
+    mock_klippy.filament_used = 1200.0
+    mock_klippy.filament_weight = 15.0
+    msg = mock_klippy._get_printing_file_info(state=PrintState.FINISH)
+    assert "Filament used: 1.2m" in msg
+    assert "5.0m" not in msg
+    assert "/" not in msg.split("Filament")[1]
+
+
+def test_finish_shows_printed_for(mock_klippy):
+    mock_klippy._message_parts = ["progress", "print_duration"]
+    mock_klippy._printing_filename = "test.gcode"
+    mock_klippy.printing_duration = 1800.0
+    msg = mock_klippy._get_printing_file_info(state=PrintState.FINISH)
+    assert "Printed for" in msg
+    assert "Printing for" not in msg
+
+
+def test_finish_hides_eta(mock_klippy):
+    mock_klippy._message_parts = ["progress", "eta", "finish_time"]
+    mock_klippy._printing_filename = "test.gcode"
+    mock_klippy.file_estimated_time = 3600.0
+    mock_klippy.printing_duration = 1800.0
+    msg = mock_klippy._get_printing_file_info(state=PrintState.FINISH)
+    assert "Estimated time left" not in msg
+    assert "Finish at" not in msg
+
+
+def test_start_hides_duration(mock_klippy):
+    mock_klippy._message_parts = ["progress", "print_duration"]
+    mock_klippy._printing_filename = "test.gcode"
+    mock_klippy.printing_duration = 1800.0
+    msg = mock_klippy._get_printing_file_info(state=PrintState.START)
+    assert "Printing for" not in msg
+
+
+def test_title_bold(mock_klippy):
+    mock_klippy._message_parts = ["progress"]
+    mock_klippy._printing_filename = "test.gcode"
+    msg = mock_klippy._get_printing_file_info()
+    assert "<b>" in msg and "</b>" in msg
+
+
+def test_progress_no_trailing_zero(mock_klippy):
+    mock_klippy._message_parts = ["progress"]
+    mock_klippy._printing_filename = "test.gcode"
+    mock_klippy.printing_progress = 0.8
+    msg = mock_klippy._get_printing_file_info()
+    assert "Progress 80%" in msg
+    assert "80.0%" not in msg


### PR DESCRIPTION
Start and finish messages used `printing_height` from live `gcode_move` websocket updates, which is
unreliable. It may hold a stale value from a previous print or reflect toolhead position during
start/finish gcode macros rather than actual print progress.

- Use `object_height` from Moonraker file metadata. For multiple object it shows maximum.
- Progress messages show both current and total height (**height: 5.2 / 19.6mm**), while start and finish messages show only the object height (**print
height: 19.6mm**).
- Replace `message_pre: str` parameter with a `PrintState` enum that controls what each message type displays.
- Start messages show only total filament, object height, and ETA — no current height or duration
- Finish/cancelled/error messages show only used filament and "Printed for" duration — no ETA or
current height
- Bold title derived from state
- Fix progress trailing .0 (80% instead of 80.0%)
- Pass `PrintState` through the notification chain instead of `finish: bool` and `message: str`
 
## Start
<img width="333" height="136" alt="start2" src="https://github.com/user-attachments/assets/b8e60341-9609-49bc-a3dd-e61905c13c0a" />

## Progress
<img width="339" height="197" alt="progress2" src="https://github.com/user-attachments/assets/54e78897-dfee-446c-abcc-4421db135fbd" />

## Finish
<img width="328" height="108" alt="finish2" src="https://github.com/user-attachments/assets/124843d4-6126-4e62-bfa7-7c6eb8143bc9" />