### PR TITLE
Fix timelapse lock file error on empty prints

### DIFF
--- a/bot/camera.py
+++ b/bot/camera.py
@@ -500,14 +500,14 @@ class Camera:
 
         lapse_dir = f"{self._base_dir}/{printing_filename}"
 
-        lock_file = Path(f"{lapse_dir}/lapse.lock")
-        if not lock_file.is_file():
-            lock_file.touch()
-
         raw_frames = glob.glob(f"{glob.escape(lapse_dir)}/*.{self._raw_frame_extension}")
         photo_count = len(raw_frames)
         if photo_count == 0:
             raise ValueError(f"Empty photos list for {printing_filename} in lapse path {lapse_dir}")
+
+        lock_file = Path(lapse_dir) / "lapse.lock"
+        if not lock_file.is_file():
+            lock_file.touch()
 
         raw_frames.sort(key=os.path.getmtime)
 


### PR DESCRIPTION
Noticed this error with testing gcode which makes no extrusions, make error clearer by moving lock file creation after the empty frames check. When a print captures no frames, the timelapse directory doesn't exist, so `lock_file.touch()` fails with `FileNotFoundError`.

## Before
```
2026-03-09 23:08:44,714 - klippy - WARNING - klippy.py:507 - Empty thumbnail_path
2026-03-09 23:09:25,117 - timelapse - WARNING - timelapse.py:293 - Failed to send time-lapse to telegram bot: [Errno 2] No such file or directory: '/home/pi/moonraker-telegram-
bot-timelapse/test_height_notification.gcode_2026-03-09_23-08/lapse.lock
```

## After
```
2026-03-09 23:06:44,943 - klippy - WARNING - klippy.py:490 - Empty thumbnail_path
2026-03-09 23:07:35,563 - timelapse - WARNING - timelapse.py:293 - Failed to send time-lapse to telegram bot: Empty photos list for test_height_notification.gcode_2026-03-08_15
-21 in lapse path /home/pi/moonraker-telegram-bot-timelapse/test_height_notification.gcode_2026-03-08_15-21
```