### PR TITLE
Redact sensitive config options in log dump

### DIFF
--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -1,4 +1,5 @@
 import configparser
+import copy
 import os
 import pathlib
 from pathlib import Path
@@ -497,15 +498,17 @@ class ConfigWrapper:
         )
 
     def dump_config_to_log(self) -> None:
+        config_copy = copy.deepcopy(self._config)
+        for option in ("bot_token", "chat_id", "password", "api_token"):
+            if config_copy.has_option("bot", option):
+                config_copy.set("bot", option, "<redacted>")
+        for sec in config_copy.sections():
+            if sec.startswith("include"):
+                config_copy.remove_section(sec)
         with open(self.bot_config.log_file, "a", encoding="utf-8") as log_file:
             log_file.write("\n*******************************************************************\n")
             log_file.write("Current Moonraker telegram bot config\n")
-            self._config.remove_option("bot", "bot_token")
-            self._config.remove_option("bot", "chat_id")
-            for sec in self._config.sections():
-                if sec.startswith("include"):
-                    self._config.remove_section(sec)
-            self._config.write(log_file)
+            config_copy.write(log_file)
             log_file.write("\n*******************************************************************\n")
 
     @property

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -1,3 +1,4 @@
+import configparser
 import pathlib
 
 import pytest
@@ -8,6 +9,7 @@ CONFIG_PATH = "tests/resources/telegram.conf"
 CONFIG_MINIMAL_PATH = "tests/resources/telegram_minimal.conf"
 CONFIG_TEMPLATE_PATH = "scripts/base_install_template"
 CONFIG_WITH_SECRETS_PATH = "tests/resources/telegram_secrets.conf"
+CONFIG_WITH_AUTH_PATH = "tests/resources/telegram_with_auth.conf"
 
 
 def test_template_config_has_no_errors():
@@ -46,3 +48,55 @@ def test_config_has_no_errors(config_helper):
 
 def test_config_bot_is_valid(config_helper):
     assert config_helper.secrets.chat_id == 16612341234 and config_helper.secrets.token == "23423423334:sdfgsdfg-dfgdfgsdfg"
+
+
+@pytest.fixture
+def config_with_auth(tmp_path):
+    config_path = pathlib.Path(CONFIG_WITH_AUTH_PATH).absolute().as_posix()
+    wrapper = ConfigWrapper(config_path)
+    wrapper.bot_config.log_file = str(tmp_path / "bot.log")
+    return wrapper
+
+
+def _read_dumped_config(wrapper) -> configparser.ConfigParser:
+    """Dump config to log and parse the written INI back."""
+    wrapper.dump_config_to_log()
+    with open(wrapper.bot_config.log_file, encoding="utf-8") as f:
+        lines = [line for line in f if not line.startswith("*") and not line.startswith("Current")]
+    dumped = configparser.ConfigParser()
+    dumped.read_string("".join(lines))
+    return dumped
+
+
+def test_dump_redacts_bot_token(config_with_auth):
+    dumped = _read_dumped_config(config_with_auth)
+    assert dumped.get("bot", "bot_token") == "<redacted>"
+
+
+def test_dump_redacts_chat_id(config_with_auth):
+    dumped = _read_dumped_config(config_with_auth)
+    assert dumped.get("bot", "chat_id") == "<redacted>"
+
+
+def test_dump_redacts_password(config_with_auth):
+    dumped = _read_dumped_config(config_with_auth)
+    assert dumped.get("bot", "password") == "<redacted>"
+
+
+def test_dump_redacts_api_token(config_with_auth):
+    dumped = _read_dumped_config(config_with_auth)
+    assert dumped.get("bot", "api_token") == "<redacted>"
+
+
+def test_dump_does_not_mutate_live_config(config_with_auth):
+    original_token = config_with_auth._config.get("bot", "bot_token")
+    config_with_auth.dump_config_to_log()
+    assert config_with_auth._config.get("bot", "bot_token") == original_token
+
+
+def test_dump_does_not_add_redacted_for_unset_options(config_helper, tmp_path):
+    """Options not present in config should not appear as <redacted>."""
+    config_helper.bot_config.log_file = str(tmp_path / "bot.log")
+    dumped = _read_dumped_config(config_helper)
+    assert not dumped.has_option("bot", "password")
+    assert not dumped.has_option("bot", "api_token")

--- a/tests/resources/telegram_with_auth.conf
+++ b/tests/resources/telegram_with_auth.conf
@@ -1,0 +1,8 @@
+[bot]
+server: 192.168.1.56
+port: 7125
+chat_id: 16612341234
+bot_token: 23423423334:sdfgsdfg-dfgdfgsdfg
+user: admin
+password: supersecretpassword
+api_token: my-secret-api-token-12345


### PR DESCRIPTION
- Redact `password` and `api_token` in addition to `bot_token` and `chat_id` when dumping config to log.
- Replace sensitive values with `<redacted>` instead of removing them, so it's visible the option was set. Should be useful when reviewing user logs.
- Use `copy.deepcopy` to avoid mutating the live config object so original can be used after that.