### PR TITLE
Remove sync method duplication in klippy.py

### DIFF
--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -6,14 +6,13 @@ from enum import Enum
 from io import BytesIO
 import logging
 import re
-import threading
 import time
 from typing import Any, Dict, Final, List, Optional, Tuple, TypeVar
 import urllib
 
 import emoji
 import httpx
-from httpx import AsyncClient, Client
+from httpx import AsyncClient
 import orjson
 from PIL import Image
 
@@ -44,8 +43,6 @@ class PrintState(Enum):
 class PowerDevice:
     def __init__(self, name: str, klippy_: "Klippy") -> None:
         self.name: str = name
-        # Todo: refactor! check lighting lock in camera
-        self._state_lock = threading.Lock()
         self._state_lock_async = asyncio.Lock()
         self._device_on: bool = False
         self._device_error: str = ""
@@ -80,19 +77,8 @@ class PowerDevice:
                 logger.error("Power device switch failed: %s", res)
             return self._device_on
 
-    # Todo: return exception?
     def switch_device_sync(self, state: bool) -> bool:
-        with self._state_lock:
-            res = self._klippy.make_request_sync("POST", f"/machine/device_power/device?device={self.name}&action={'on' if state else 'off'}")
-            if res.is_success:
-                self._device_on = state
-                self._device_error = ""
-            else:
-                resp_json = orjson.loads(res.text)
-                if "error" in resp_json and "message" in resp_json["error"]:
-                    self._device_error = resp_json["error"]["message"]
-                logger.error("Power device switch failed: %s", res)
-            return self._device_on
+        return self._klippy.call_async(self.switch_device(state))
 
 
 class Klippy:
@@ -161,7 +147,6 @@ class Klippy:
             logger.setLevel(logging.DEBUG)
 
         self._client: AsyncClient = AsyncClient(verify=self._ssl_verify)
-        self._client_sync: Client = Client(verify=self._ssl_verify)
         self._loop: Optional[asyncio.AbstractEventLoop] = None
 
     async def async_init(self) -> None:
@@ -364,20 +349,6 @@ class Klippy:
         except httpx.HTTPError:
             logger.exception("Failed to refresh token")
 
-    def _refresh_moonraker_token_sync(self) -> None:
-        if not self._refresh_token:
-            return
-        res = self._client_sync.post(f"{self._host}/access/refresh_jwt", content=orjson.dumps({"refresh_token": self._refresh_token}), timeout=15)
-
-        try:
-            res.raise_for_status()
-            logger.debug("JWT token successfully refreshed")
-            self._jwt_token = orjson.loads(res.text)["result"]["token"]
-        except httpx.HTTPError:
-            logger.exception(
-                "Failed to refresh token",
-            )
-
     async def make_request(self, method: str, url_path: str, json: Any = None, files: Any = None, timeout: int = 30) -> httpx.Response:
         res = await self._client.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=self._headers, files=files, timeout=timeout)
         if res.status_code == 401:  # Unauthorized
@@ -389,20 +360,6 @@ class Klippy:
             res.raise_for_status()
         except httpx.HTTPError:
             logger.exception("Failed to make request asynchronously")
-
-        return res
-
-    def make_request_sync(self, method: str, url_path: str, json: Any = None, files: Any = None, timeout: int = 30) -> httpx.Response:
-        res = self._client_sync.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=self._headers, files=files, timeout=timeout)
-        if res.status_code == 401:  # Unauthorized
-            logger.debug("JWT token expired, refreshing...")
-            self._refresh_moonraker_token_sync()
-            res = self._client_sync.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=self._headers, files=files, timeout=timeout)
-
-        try:
-            res.raise_for_status()
-        except httpx.HTTPError:
-            logger.exception("Failed to make request synchronously")
 
         return res
 
@@ -501,7 +458,7 @@ class Klippy:
         await self.make_request("GET", f"/printer/gcode/script?script={gcode}")
 
     def execute_gcode_script_sync(self, gcode: str) -> None:
-        self.make_request_sync("GET", f"/printer/gcode/script?script={gcode}")
+        self.call_async(self.execute_gcode_script(gcode))
 
     def _get_eta(self) -> timedelta:
         if self._eta_source == "slicer":

--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -163,10 +163,10 @@ class Klippy:
         self._client: AsyncClient = AsyncClient(verify=self._ssl_verify)
         self._client_sync: Client = Client(verify=self._ssl_verify)
         self._loop: Optional[asyncio.AbstractEventLoop] = None
-        self._auth_moonraker()
 
     async def async_init(self) -> None:
         self._loop = asyncio.get_running_loop()
+        await self._auth_moonraker()
 
     def call_async(self, coro: Coroutine[Any, Any, T]) -> T:
         assert self._loop is not None, "Event loop not set. Call async_init() first."
@@ -338,11 +338,11 @@ class Klippy:
     def _get_marco_list(self) -> List[str]:
         return [key for key in self._get_full_marco_list() if key not in self._hidden_macros and (True if self._show_private_macros else not key.startswith("_"))]
 
-    def _auth_moonraker(self) -> None:
+    async def _auth_moonraker(self) -> None:
         if not self._user or not self._passwd:
             return
 
-        res = httpx.post(f"{self._host}/access/login", json={"username": self._user, "password": self._passwd}, timeout=15, verify=self._ssl_verify)
+        res = await self._client.post(f"{self._host}/access/login", json={"username": self._user, "password": self._passwd}, timeout=15)
 
         try:
             res.raise_for_status()

--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -1,5 +1,6 @@
 # Todo: class for printer states!
 import asyncio
+from collections.abc import Coroutine
 from datetime import datetime, timedelta
 from enum import Enum
 from io import BytesIO
@@ -7,7 +8,7 @@ import logging
 import re
 import threading
 import time
-from typing import Any, Dict, Final, List, Optional, Tuple
+from typing import Any, Dict, Final, List, Optional, Tuple, TypeVar
 import urllib
 
 import emoji
@@ -17,6 +18,8 @@ import orjson
 from PIL import Image
 
 from configuration import ConfigWrapper
+
+T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
 
@@ -159,7 +162,15 @@ class Klippy:
 
         self._client: AsyncClient = AsyncClient(verify=self._ssl_verify)
         self._client_sync: Client = Client(verify=self._ssl_verify)
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._auth_moonraker()
+
+    async def async_init(self) -> None:
+        self._loop = asyncio.get_running_loop()
+
+    def call_async(self, coro: Coroutine[Any, Any, T]) -> T:
+        assert self._loop is not None, "Event loop not set. Call async_init() first."
+        return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
 
     def prepare_sens_dict_subscribe(self) -> Dict[str, Any]:
         self._sensors_dict = {}

--- a/bot/main.py
+++ b/bot/main.py
@@ -1294,6 +1294,7 @@ def start_bot(bot_token: str, socks: str) -> Application:  # type: ignore[type-a
 
 
 async def start_scheduler(context: ContextTypes.DEFAULT_TYPE) -> None:
+    await klippy.async_init()
     a_scheduler.start()
     a_scheduler.add_job(
         greeting_message,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ select = [
     "FURB",  # refurb
     "G",     # flake8-logging-format
     "I",     # isort
-    "ICN",
+    "ICN",   # flake8-import-conventions
     "LOG",   # flake8-logging
     "PERF",  # perflint
     "PIE",   # flake8-pie
@@ -86,16 +86,16 @@ select = [
     "T20",   # flake8-print
     "TCH",   # flake8-type-checking
     "TID",   # flake8-tidy-imports
-    "TRY",
+    "TRY",   # tryceratops
     "W",     # pycodestyle warnings
 ]
 ignore = [
+    "D",       # pydocstyle
     "E501",    # line length handled by formatter
     "PERF203", # try-except in loop — intentional error handling
     "RUF006",  # fire-and-forget asyncio task — existing pattern
     "SIM108",  # ternary — would produce very long lines
-    "D",
-    "TD"
+    "TD",      # flake8-todos
 ]
 [tool.ruff.lint.isort]
 force-sort-within-sections = true

--- a/tests/klippy_test.py
+++ b/tests/klippy_test.py
@@ -1,9 +1,10 @@
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
 
-from bot.klippy import Klippy, PrintState  # type: ignore
+from bot.klippy import Klippy, PowerDevice, PrintState  # type: ignore
 
 test_sensors = {
     "heater": {"temperature": 155.345325234, "target": 255.343434, "power": 0.60},
@@ -39,8 +40,7 @@ def mock_klippy():
     config.secrets.passwd = ""
     config.secrets.api_token = ""
 
-    klippy = Klippy(config, None)
-    return klippy
+    return Klippy(config, None)
 
 
 @pytest.mark.asyncio
@@ -197,3 +197,50 @@ def test_progress_no_trailing_zero(mock_klippy):
     msg = mock_klippy._get_printing_file_info()
     assert "Progress 80%" in msg
     assert "80.0%" not in msg
+
+
+@pytest.mark.asyncio
+async def test_switch_device_sync_delegates_to_async(mock_klippy):
+    mock_klippy._loop = asyncio.get_running_loop()
+    ok_response = httpx.Response(status_code=200, text='{"result":"ok"}', request=httpx.Request("POST", "http://localhost:7125/machine/device_power/device"))
+    mock_klippy.make_request = AsyncMock(return_value=ok_response)
+
+    device = PowerDevice("test_light", mock_klippy)
+
+    loop = asyncio.get_running_loop()
+    result = await loop.run_in_executor(None, device.switch_device_sync, True)
+
+    assert result is True
+    assert device.device_state is True
+    mock_klippy.make_request.assert_called_once_with("POST", "/machine/device_power/device?device=test_light&action=on")
+
+
+@pytest.mark.asyncio
+async def test_execute_gcode_script_sync_delegates_to_async(mock_klippy):
+    mock_klippy._loop = asyncio.get_running_loop()
+    ok_response = httpx.Response(status_code=200, text='{"result":"ok"}', request=httpx.Request("GET", "http://localhost:7125/printer/gcode/script"))
+    mock_klippy.make_request = AsyncMock(return_value=ok_response)
+
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, mock_klippy.execute_gcode_script_sync, "G28")
+
+    mock_klippy.make_request.assert_called_once_with("GET", "/printer/gcode/script?script=G28")
+
+
+@pytest.mark.asyncio
+async def test_switch_device_sync_reports_error(mock_klippy):
+    mock_klippy._loop = asyncio.get_running_loop()
+    err_response = httpx.Response(
+        status_code=400,
+        text='{"error":{"message":"device busy"}}',
+        request=httpx.Request("POST", "http://localhost:7125/machine/device_power/device"),
+    )
+    mock_klippy.make_request = AsyncMock(return_value=err_response)
+
+    device = PowerDevice("test_light", mock_klippy)
+
+    loop = asyncio.get_running_loop()
+    result = await loop.run_in_executor(None, device.switch_device_sync, True)
+
+    assert result is False
+    assert device.device_error == "device busy"


### PR DESCRIPTION
- Replace duplicated sync HTTP client and methods with `call_async` bridge that
dispatches to async versions via `run_coroutine_threadsafe`
- Make `_auth_moonraker` async, move from `__init__` to `async_init`
- `switch_device_sync` and `execute_gcode_script_sync` now delegate to their async
counterparts