### PR TITLE
Fix pathlib rework issues and improve Path usage

### DIFF
--- a/bot/camera.py
+++ b/bot/camera.py
@@ -613,7 +613,7 @@ class Camera:
     # Todo: check for 64 symbols length in lapse names
     def detect_unfinished_lapses(self) -> List[str]:
         # Todo: detect unstarted timelapse builds? folder with pics and no mp4 files
-        return [el.parent.as_posix() for el in Path(f"{self._base_dir}").rglob("*.lock")]
+        return [el.parent.name for el in Path(self._base_dir).rglob("*.lock")]
 
     def cleanup_unfinished_lapses(self) -> None:
         for lapse_name in self.detect_unfinished_lapses():

--- a/bot/camera.py
+++ b/bot/camera.py
@@ -424,9 +424,9 @@ class Camera:
 
         video_bio = BytesIO()
         video_bio.name = "video.mp4"
-        with Path(filepath).open("rb") as video_file:
+        with filepath.open("rb") as video_file:
             video_bio.write(video_file.read())
-        Path(filepath).unlink()
+        filepath.unlink()
         video_bio.seek(0)
         return video_bio, thumb_bio, width, height
 
@@ -776,9 +776,9 @@ class MjpegCamera(Camera):
 
         video_bio = BytesIO()
         video_bio.name = "video.mp4"
-        with Path(filepath).open("rb") as video_file:
+        with filepath.open("rb") as video_file:
             video_bio.write(video_file.read())
-        Path(filepath).unlink()
+        filepath.unlink()
         video_bio.seek(0)
         return video_bio, thumb_bio, width, height
 
@@ -821,9 +821,9 @@ class RawStreamCamera(MjpegCamera):
 
         video_bio = BytesIO()
         video_bio.name = "video.mp4"
-        if Path(filepath).is_file():
-            with Path(filepath).open("rb") as video_file:
+        if filepath.is_file():
+            with filepath.open("rb") as video_file:
                 video_bio.write(video_file.read())
-            Path(filepath).unlink()
+            filepath.unlink()
         video_bio.seek(0)
         return video_bio, thumb_bio, width, height

--- a/bot/camera.py
+++ b/bot/camera.py
@@ -2,7 +2,6 @@ import asyncio
 import contextlib
 import functools
 from functools import wraps
-import glob
 from io import BytesIO
 import logging
 import math
@@ -96,8 +95,8 @@ class Camera:
         self._klippy: Klippy = klippy
 
         # Todo: refactor into timelapse class
-        self._base_dir: str = config.timelapse.base_dir
-        self._ready_dir: str = config.timelapse.ready_dir
+        self._base_dir: Path = Path(config.timelapse.base_dir)
+        self._ready_dir: Optional[Path] = Path(config.timelapse.ready_dir) if config.timelapse.ready_dir else None
         self._cleanup: bool = config.timelapse.cleanup
 
         self._target_fps: int = 15
@@ -175,8 +174,8 @@ class Camera:
             self._light_need_off = new_value
 
     @property
-    def lapse_dir(self) -> str:
-        return f"{self._base_dir}/{self._klippy.printing_filename_with_time}"
+    def lapse_dir(self) -> Path:
+        return self._base_dir / self._klippy.printing_filename_with_time
 
     @property
     def light_requests(self) -> int:
@@ -433,7 +432,7 @@ class Camera:
     def take_lapse_photo(self, gcode: str = "") -> None:
         logger.debug("Take_lapse_photo called with gcode `%s`", gcode)
         # Todo: check for space available?
-        Path(self.lapse_dir).mkdir(parents=True, exist_ok=True)
+        self.lapse_dir.mkdir(parents=True, exist_ok=True)
         # never add self in params there!
         raw_frame = self._take_raw_frame(rgb=False)
 
@@ -449,7 +448,7 @@ class Camera:
 
         os_nice(15)
 
-        np.savez_compressed(f"{self.lapse_dir}/{time.time()}", raw=raw_frame)
+        np.savez_compressed(self.lapse_dir / str(time.time()), raw=raw_frame)
 
         raw_frame_rgb = raw_frame[:, :, [2, 1, 0]].copy()
         del raw_frame
@@ -459,8 +458,8 @@ class Camera:
         if self._save_lapse_photos_as_images:
             with self.take_photo(raw_frame_rgb) as photo:
                 # Fixme: jpeg_low is bad file extension!
-                filename = f"{self.lapse_dir}/{time.time()}.{self._img_extension}"
-                with Path(filename).open("wb") as outfile:
+                filename = self.lapse_dir / f"{time.time()}.{self._img_extension}"
+                with filename.open("wb") as outfile:
                     outfile.write(photo.getvalue())
                 photo.close()
 
@@ -501,14 +500,14 @@ class Camera:
 
         os_nice(15)
 
-        lapse_dir = f"{self._base_dir}/{printing_filename}"
+        lapse_dir = self._base_dir / printing_filename
 
-        raw_frames = list(Path(glob.escape(lapse_dir)).glob(f"*.{self._raw_frame_extension}"))
+        raw_frames = list(lapse_dir.glob(f"*.{self._raw_frame_extension}"))
         photo_count = len(raw_frames)
         if photo_count == 0:
             raise ValueError(f"Empty photos list for {printing_filename} in lapse path {lapse_dir}")  # noqa: TRY003
 
-        lock_file = Path(lapse_dir) / "lapse.lock"
+        lock_file = lapse_dir / "lapse.lock"
         if not lock_file.is_file():
             lock_file.touch()
 
@@ -521,10 +520,9 @@ class Camera:
         height, width, layers = img.shape
         thumb_bio = self._create_thumb(img)
 
-        video_filename = Path(printing_filename).name
-        video_filepath = f"{lapse_dir}/{video_filename}.mp4"
-        if Path(video_filepath).is_file():
-            Path(video_filepath).unlink()
+        video_filepath = lapse_dir / f"{Path(printing_filename).name}.mp4"
+        if video_filepath.is_file():
+            video_filepath.unlink()
 
         lapse_fps = self._calculate_fps(photo_count)
         odd_frames = 1
@@ -534,7 +532,7 @@ class Camera:
 
         with self._camera_lock:
             out = ffmpegcv.VideoWriter(
-                video_filepath,
+                video_filepath.as_posix(),
                 codec=self._fourcc,
                 fps=lapse_fps,
             )
@@ -575,16 +573,16 @@ class Camera:
 
         video_bytes: bytes = b""
 
-        with Path(video_filepath).open("rb") as fh:
+        with video_filepath.open("rb") as fh:
             video_bytes = fh.read()
-        if self._ready_dir and Path(self._ready_dir).is_dir():
+        if self._ready_dir and self._ready_dir.is_dir():
             asyncio.run_coroutine_threadsafe(info_mess.edit_text(text="Copy lapse to target ditectory"), loop).result()
-            target_video_file = f"{self._ready_dir}/{printing_filename}.mp4"
-            Path(target_video_file).parent.mkdir(parents=True, exist_ok=True)
-            with Path(target_video_file).open("wb") as cpf:
+            target_video_file = self._ready_dir / f"{printing_filename}.mp4"
+            target_video_file.parent.mkdir(parents=True, exist_ok=True)
+            with target_video_file.open("wb") as cpf:
                 cpf.write(video_bytes)
 
-        Path(f"{lapse_dir}/lapse.lock").unlink(missing_ok=True)
+        (lapse_dir / "lapse.lock").unlink(missing_ok=True)
 
         os_nice(0)
 
@@ -594,18 +592,18 @@ class Camera:
         thumb_bio = None  # type: ignore[assignment]
         del thumb_bio
 
-        return video_bytes, res_thumb_bytes, width, height, video_filepath, gcode_name
+        return video_bytes, res_thumb_bytes, width, height, str(video_filepath), gcode_name
 
     def cleanup(self, lapse_filename: str, force: bool = False) -> None:
-        lapse_dir = f"{self._base_dir}/{lapse_filename}"
+        lapse_dir = self._base_dir / lapse_filename
         if self._cleanup or force:
-            for filename in Path(f"{glob.escape(lapse_dir)}").glob("*"):
+            for filename in lapse_dir.iterdir():
                 filename.unlink()
-            Path(lapse_dir).rmdir()
+            lapse_dir.rmdir()
 
     def clean(self) -> None:
-        if self._cleanup and self._klippy.printing_filename and Path(self.lapse_dir).is_dir():
-            for filename in Path(f"{glob.escape(self.lapse_dir)}").glob("*"):
+        if self._cleanup and self._klippy.printing_filename and self.lapse_dir.is_dir():
+            for filename in self.lapse_dir.iterdir():
                 filename.unlink()
 
     # Todo: check if lapse was in subfolder ( alike gcode folders)
@@ -613,7 +611,7 @@ class Camera:
     # Todo: check for 64 symbols length in lapse names
     def detect_unfinished_lapses(self) -> List[str]:
         # Todo: detect unstarted timelapse builds? folder with pics and no mp4 files
-        return [el.parent.name for el in Path(self._base_dir).rglob("*.lock")]
+        return [el.parent.name for el in self._base_dir.rglob("*.lock")]
 
     def cleanup_unfinished_lapses(self) -> None:
         for lapse_name in self.detect_unfinished_lapses():
@@ -692,7 +690,7 @@ class MjpegCamera(Camera):
     def take_lapse_photo(self, gcode: str = "") -> None:
         logger.debug("Take_lapse_photo called with gcode `%s`", gcode)
         # Todo: check for space available?
-        Path(self.lapse_dir).mkdir(parents=True, exist_ok=True)
+        self.lapse_dir.mkdir(parents=True, exist_ok=True)
         with self.take_photo(force_rotate=False) as photo:
             if gcode:
                 try:
@@ -701,8 +699,8 @@ class MjpegCamera(Camera):
                     logger.exception("Failed to execute gcode before timelapse shot")
 
             if photo.getbuffer().nbytes > 0:
-                filename = f"{self.lapse_dir}/{time.time()}.{self._img_extension}"
-                with Path(filename).open("wb") as outfile:
+                filename = self.lapse_dir / f"{time.time()}.{self._img_extension}"
+                with filename.open("wb") as outfile:
                     outfile.write(photo.getvalue())
             else:
                 self._lapse_missed_frames += 1

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -203,8 +203,8 @@ class BotConfig(ConfigHelper):
         self.light_device_name: str = self._get_str("light_device", default="")
         self.poweroff_device_name: str = self._get_str("power_device", default="")
         self.debug: bool = self._get_boolean("debug", default=False)
-        self.log_path: str = self._get_str("log_path", default="/tmp")
-        self.log_file: str = self._get_str("log_path", default="/tmp")
+        self.log_path: Path = Path(self._get_str("log_path", default="/tmp"))
+        self.log_file: Path = Path(self._get_str("log_path", default="/tmp"))
         self.upload_path: str = self._get_str("upload_path", default="")
         self.services: List[str] = self._get_list("services", default=["klipper", "moonraker"])
         self.log_parser: bool = self._get_boolean("log_parser", default=False)
@@ -227,12 +227,12 @@ class BotConfig(ConfigHelper):
 
     def log_path_update(self, logfile: str) -> None:
         if logfile:
-            self.log_file = logfile
-        if not Path(self.log_file).suffix:
-            self.log_file += "/telegram.log"
-        if self.log_file != "/tmp" or str(Path(self.log_file).parent) != "/tmp":
-            Path(self.log_file).parent.mkdir(parents=True, exist_ok=True)
-        self.log_path = Path(self.log_file).parent.as_posix()
+            self.log_file = Path(logfile)
+        if not self.log_file.suffix:
+            self.log_file = self.log_file / "telegram.log"
+        if str(self.log_file) != "/tmp" or str(self.log_file.parent) != "/tmp":
+            self.log_file.parent.mkdir(parents=True, exist_ok=True)
+        self.log_path = self.log_file.parent
 
 
 class CameraConfig(ConfigHelper):
@@ -503,7 +503,7 @@ class ConfigWrapper:
         for sec in config_copy.sections():
             if sec.startswith("include"):
                 config_copy.remove_section(sec)
-        with Path(self.bot_config.log_file).open("a", encoding="utf-8") as log_file:
+        with self.bot_config.log_file.open("a", encoding="utf-8") as log_file:
             log_file.write("\n*******************************************************************\n")
             log_file.write("Current Moonraker telegram bot config\n")
             config_copy.write(log_file)

--- a/bot/main.py
+++ b/bot/main.py
@@ -390,7 +390,7 @@ async def bot_restart(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
 def prepare_log_files() -> tuple[List[str], bool, Optional[str]]:
     dmesg_success = True
     dmesg_error = None
-    log_dir = Path(config_wrap.bot_config.log_path)
+    log_dir = config_wrap.bot_config.log_path
 
     dmesg_file = log_dir / "dmesg.txt"
     if dmesg_file.exists():
@@ -451,7 +451,7 @@ async def send_logs_no_confirm(effective_message: Message) -> None:
         do_quote=True,
     )
 
-    log_dir = Path(config_wrap.bot_config.log_path)
+    log_dir = config_wrap.bot_config.log_path
     logs_list: List[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]] = []
     for log_file in prepare_log_files()[0]:
         try:
@@ -494,7 +494,7 @@ async def upload_logs_no_confirm(effective_message: Message) -> None:
         await resp_message.edit_text(f"Dmesg log file creation error {dmesg_error}")
         return
 
-    log_dir = Path(config_wrap.bot_config.log_path)
+    log_dir = config_wrap.bot_config.log_path
     archive_path = log_dir / "logs.tar.xz"
 
     if await anyio.Path(archive_path).exists():
@@ -509,7 +509,7 @@ async def upload_logs_no_confirm(effective_message: Message) -> None:
     await resp_message.edit_text("Uploading logs to parser")
     await effective_message.get_bot().send_chat_action(chat_id=config_wrap.secrets.chat_id, action=ChatAction.UPLOAD_DOCUMENT)
 
-    async with aiofiles.open(f"{config_wrap.bot_config.log_path}/logs.tar.xz", "rb") as log_archive_ojb, httpx.AsyncClient() as client_loc:
+    async with aiofiles.open(config_wrap.bot_config.log_path / "logs.tar.xz", "rb") as log_archive_ojb, httpx.AsyncClient() as client_loc:
         resp = await client_loc.post(url="https://coderus.openrepos.net/klipper_logs", files={"tarfile": await log_archive_ojb.read()}, follow_redirects=False, timeout=25)
         if resp.status_code < 400:
             logs_path = resp.headers["location"]

--- a/bot/main.py
+++ b/bot/main.py
@@ -390,18 +390,21 @@ async def bot_restart(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
 def prepare_log_files() -> tuple[List[str], bool, Optional[str]]:
     dmesg_success = True
     dmesg_error = None
+    log_dir = Path(config_wrap.bot_config.log_path)
 
-    if Path(f"{config_wrap.bot_config.log_path}/dmesg.txt").exists():
-        Path(f"{config_wrap.bot_config.log_path}/dmesg.txt").unlink()
+    dmesg_file = log_dir / "dmesg.txt"
+    if dmesg_file.exists():
+        dmesg_file.unlink()
 
-    dmesg_res = subprocess.run(f"dmesg -T > {config_wrap.bot_config.log_path}/dmesg.txt", shell=True, executable="/bin/bash", check=False, capture_output=True)
+    dmesg_res = subprocess.run(f"dmesg -T > {dmesg_file}", shell=True, executable="/bin/bash", check=False, capture_output=True)
     if dmesg_res.returncode != 0:
         logger.warning("dmesg file creation error: %s %s", dmesg_res.stdout.decode("utf-8"), dmesg_res.stderr.decode("utf-8"))
         dmesg_error = dmesg_res.stderr.decode("utf-8")
         dmesg_success = False
 
-    if Path(f"{config_wrap.bot_config.log_path}/debug.txt").exists():
-        Path(f"{config_wrap.bot_config.log_path}/debug.txt").unlink()
+    debug_file_path = log_dir / "debug.txt"
+    if debug_file_path.exists():
+        debug_file_path.unlink()
 
     commands = [
         "lsb_release -a",
@@ -417,19 +420,19 @@ def prepare_log_files() -> tuple[List[str], bool, Optional[str]]:
     ]
     for command in commands:
         subprocess.run(
-            f'echo >> {config_wrap.bot_config.log_path}/debug.txt;echo "{command}" >> {config_wrap.bot_config.log_path}/debug.txt;{command} >> {config_wrap.bot_config.log_path}/debug.txt',
+            f'echo >> {debug_file_path};echo "{command}" >> {debug_file_path};{command} >> {debug_file_path}',
             shell=True,
             executable="/bin/bash",
             check=False,
         )
 
     files = ["/boot/config.txt", "/boot/cmdline.txt", "/boot/armbianEnv.txt", "/boot/orangepiEnv.txt", "/boot/BoardEnv.txt", "/boot/env.txt"]
-    with Path(config_wrap.bot_config.log_path + "/debug.txt").open("a", encoding="utf-8") as debug_file:
+    with debug_file_path.open("a", encoding="utf-8") as debug_file:
         for file in files:
             try:
                 if Path(file).exists():
                     debug_file.write(f"\n{file}\n")
-                    with Path(file).open("r", encoding="utf-8") as file_obj:
+                    with Path(file).open(encoding="utf-8") as file_obj:
                         debug_file.writelines(file_obj.readlines())
             except Exception as err:
                 logger.warning(err)
@@ -448,11 +451,13 @@ async def send_logs_no_confirm(effective_message: Message) -> None:
         do_quote=True,
     )
 
+    log_dir = Path(config_wrap.bot_config.log_path)
     logs_list: List[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]] = []
     for log_file in prepare_log_files()[0]:
         try:
-            if await anyio.Path(f"{config_wrap.bot_config.log_path}/{log_file}").exists():
-                async with aiofiles.open(f"{config_wrap.bot_config.log_path}/{log_file}", "rb") as fh:
+            log_file_path = log_dir / log_file
+            if await anyio.Path(log_file_path).exists():
+                async with aiofiles.open(log_file_path, "rb") as fh:
                     logs_list.append(InputMediaDocument(await fh.read(), filename=log_file))
         except FileNotFoundError as err:
             logger.warning(err)
@@ -489,13 +494,17 @@ async def upload_logs_no_confirm(effective_message: Message) -> None:
         await resp_message.edit_text(f"Dmesg log file creation error {dmesg_error}")
         return
 
-    if await anyio.Path(f"{config_wrap.bot_config.log_path}/logs.tar.xz").exists():
-        await anyio.Path(f"{config_wrap.bot_config.log_path}/logs.tar.xz").unlink()
+    log_dir = Path(config_wrap.bot_config.log_path)
+    archive_path = log_dir / "logs.tar.xz"
 
-    with tarfile.open(f"{config_wrap.bot_config.log_path}/logs.tar.xz", "w:xz") as tar:
+    if await anyio.Path(archive_path).exists():
+        await anyio.Path(archive_path).unlink()
+
+    with tarfile.open(archive_path, "w:xz") as tar:
         for file in files_list:
-            if await anyio.Path(f"{config_wrap.bot_config.log_path}/{file}").exists():
-                tar.add(Path(f"{config_wrap.bot_config.log_path}/{file}"), arcname=file)
+            file_path = log_dir / file
+            if await anyio.Path(file_path).exists():
+                tar.add(file_path, arcname=file)
 
     await resp_message.edit_text("Uploading logs to parser")
     await effective_message.get_bot().send_chat_action(chat_id=config_wrap.secrets.chat_id, action=ChatAction.UPLOAD_DOCUMENT)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,4 @@
-import os
 from pathlib import Path
 import sys
 
-sys.path.append(os.path.realpath(Path(__file__).parent.as_posix() + "/../bot"))
+sys.path.append(str(Path(__file__).resolve().parent.parent / "bot"))

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -54,14 +54,14 @@ def test_config_bot_is_valid(config_helper):
 def config_with_auth(tmp_path):
     config_path = pathlib.Path(CONFIG_WITH_AUTH_PATH).absolute().as_posix()
     wrapper = ConfigWrapper(config_path)
-    wrapper.bot_config.log_file = str(tmp_path / "bot.log")
+    wrapper.bot_config.log_file = tmp_path / "bot.log"
     return wrapper
 
 
 def _read_dumped_config(wrapper) -> configparser.ConfigParser:
     """Dump config to log and parse the written INI back."""
     wrapper.dump_config_to_log()
-    with pathlib.Path(wrapper.bot_config.log_file).open(encoding="utf-8") as f:
+    with wrapper.bot_config.log_file.open(encoding="utf-8") as f:
         lines = [line for line in f if not line.startswith("*") and not line.startswith("Current")]
     dumped = configparser.ConfigParser()
     dumped.read_string("".join(lines))
@@ -96,7 +96,7 @@ def test_dump_does_not_mutate_live_config(config_with_auth):
 
 def test_dump_does_not_add_redacted_for_unset_options(config_helper, tmp_path):
     """Options not present in config should not appear as <redacted>."""
-    config_helper.bot_config.log_file = str(tmp_path / "bot.log")
+    config_helper.bot_config.log_file = tmp_path / "bot.log"
     dumped = _read_dumped_config(config_helper)
     assert not dumped.has_option("bot", "password")
     assert not dumped.has_option("bot", "api_token")


### PR DESCRIPTION
Improvements for #418.

- Fix `detect_unfinished_lapses` returning full path instead of directory name
- Fix `glob.escape` incorrectly used with `Path.glob`. Use `Path.iterdir` and `Path.glob`
properly
- Remove redundant `Path()` wrapping on variables already of type `Path`
- Store `_base_dir`, `_ready_dir`, `log_path`, `log_file` as `Path` objects instead of `str`
- Remove `glob` import from `camera.py`. It's fully replaced by Path operations
- Simplify tests `sys.path` setup with `pathlib`