### PR TITLE
Few more improvements for Path usage

### DIFF
--- a/bot/camera.py
+++ b/bot/camera.py
@@ -95,8 +95,8 @@ class Camera:
         self._klippy: Klippy = klippy
 
         # Todo: refactor into timelapse class
-        self._base_dir: Path = Path(config.timelapse.base_dir)
-        self._ready_dir: Optional[Path] = Path(config.timelapse.ready_dir) if config.timelapse.ready_dir else None
+        self._base_dir: Path = config.timelapse.base_dir
+        self._ready_dir: Optional[Path] = config.timelapse.ready_dir
         self._cleanup: bool = config.timelapse.cleanup
 
         self._target_fps: int = 15

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -145,13 +145,13 @@ class SecretsConfig(ConfigHelper):
 
     def __init__(self, config: configparser.ConfigParser):
         secrets_path = Path(config.get("secrets", "secrets_path", fallback="")).expanduser()
-        secrets_path_default_name = Path(config.get("secrets", "secrets_path", fallback="") + "/secrets.conf").expanduser()
+        secrets_path_default_name = (secrets_path / "secrets.conf").expanduser()
         conf = configparser.ConfigParser(allow_no_value=True, inline_comment_prefixes=(";", "#"))
         if secrets_path and secrets_path.is_file():
-            conf.read(secrets_path.as_posix())
+            conf.read(secrets_path)
             super().__init__(conf)
         elif secrets_path_default_name and secrets_path_default_name.is_file():
-            conf.read(secrets_path_default_name.as_posix())
+            conf.read(secrets_path_default_name)
             super().__init__(conf)
         else:
             self._section = "bot"

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -330,8 +330,9 @@ class TimelapseConfig(ConfigHelper):
     def __init__(self, config: configparser.ConfigParser):
         super().__init__(config)
         self.enabled: bool = config.has_section(self._section)
-        self.base_dir: str = self._get_str("basedir", default="~/moonraker-telegram-bot-timelapse")
-        self.ready_dir: str = self._get_str("copy_finished_timelapse_dir", default="")
+        self.base_dir: Path = Path(self._get_str("basedir", default="~/moonraker-telegram-bot-timelapse"))
+        _ready_dir = self._get_str("copy_finished_timelapse_dir", default="")
+        self.ready_dir: Optional[Path] = Path(_ready_dir) if _ready_dir else None
         self.cleanup: bool = self._get_boolean("cleanup", default=True)
         self.height: float = self._get_float("height", default=0.0, min_value=0.0)
         self.interval: int = self._get_int("time", default=0, min_value=0)
@@ -349,11 +350,11 @@ class TimelapseConfig(ConfigHelper):
         self._init_paths()
 
     def _init_paths(self) -> None:
-        self.base_dir = Path(self.base_dir).expanduser().as_posix()
+        self.base_dir = self.base_dir.expanduser()
         if self.enabled:
-            Path(self.base_dir).mkdir(parents=True, exist_ok=True)
+            self.base_dir.mkdir(parents=True, exist_ok=True)
         if self.ready_dir:
-            self.ready_dir = Path(self.ready_dir).expanduser().as_posix()
+            self.ready_dir = self.ready_dir.expanduser()
 
 
 class TelegramUIConfig(ConfigHelper):


### PR DESCRIPTION
1. store `base_dir` and `ready_dir` as `Path` in `TimelapseConfig`
2. remove unnecessary `.as_posix()`, `configparser.read()` accepts `Path`