### PR TITLE
Modernise type hints

### DIFF
--- a/bot/assets/ffmpegcv_custom.py
+++ b/bot/assets/ffmpegcv_custom.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from ffmpegcv.ffmpeg_reader import FFmpegReader, get_outnumpyshape, get_videofilter_cpu  # type: ignore[import-untyped]
 from ffmpegcv.stream_info import get_info  # type: ignore[import-untyped]
@@ -14,15 +16,15 @@ class FFmpegReaderStreamRTCustom(FFmpegReader):  # type: ignore[misc]
     @staticmethod
     def VideoReader(
         stream_url: str,
-        codec: Optional[str],
+        codec: str | None,
         pix_fmt: str,
-        crop_xywh: Optional[tuple[int, int, int, int]],
-        resize: Optional[tuple[int, int]],
+        crop_xywh: tuple[int, int, int, int] | None,
+        resize: tuple[int, int] | None,
         resize_keepratio: bool,
         resize_keepratioalign: str,
-        timeout: Optional[int],
+        timeout: int | None,
         videoinfo: Any,
-    ) -> "FFmpegReaderStreamRTCustom":
+    ) -> FFmpegReaderStreamRTCustom:
         vid = FFmpegReaderStreamRTCustom()
         videoinfo = videoinfo or get_info(stream_url, timeout)
         vid.origin_width = videoinfo.width
@@ -54,13 +56,13 @@ class FFmpegReaderStreamRTCustom(FFmpegReader):  # type: ignore[misc]
 
 def FFmpegReaderStreamRTCustomInit(
     stream_url: str,
-    codec: Optional[str] = None,
+    codec: str | None = None,
     pix_fmt: str = "bgr24",
-    crop_xywh: Optional[tuple[int, int, int, int]] = None,
-    resize: Optional[tuple[int, int]] = None,
+    crop_xywh: tuple[int, int, int, int] | None = None,
+    resize: tuple[int, int] | None = None,
     resize_keepratio: bool = True,
     resize_keepratioalign: str = "center",
-    timeout: Optional[int] = None,
+    timeout: int | None = None,
     videoinfo: Any = None,
 ) -> FFmpegReaderStreamRTCustom:
     return FFmpegReaderStreamRTCustom.VideoReader(stream_url, codec, pix_fmt, crop_xywh, resize, resize_keepratio, resize_keepratioalign, timeout=timeout, videoinfo=videoinfo)

--- a/bot/assets/ffmpegcv_custom.py
+++ b/bot/assets/ffmpegcv_custom.py
@@ -14,7 +14,7 @@ class FFmpegReaderStreamRTCustom(FFmpegReader):  # type: ignore[misc]
         super().__init__()
 
     @staticmethod
-    def VideoReader(
+    def VideoReader(  # noqa: N802
         stream_url: str,
         codec: str | None,
         pix_fmt: str,
@@ -54,7 +54,7 @@ class FFmpegReaderStreamRTCustom(FFmpegReader):  # type: ignore[misc]
         return vid
 
 
-def FFmpegReaderStreamRTCustomInit(
+def FFmpegReaderStreamRTCustomInit(  # noqa: N802
     stream_url: str,
     codec: str | None = None,
     pix_fmt: str = "bgr24",

--- a/bot/assets/ffmpegcv_custom.py
+++ b/bot/assets/ffmpegcv_custom.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 from ffmpegcv.ffmpeg_reader import FFmpegReader, get_outnumpyshape, get_videofilter_cpu  # type: ignore[import-untyped]
 from ffmpegcv.stream_info import get_info  # type: ignore[import-untyped]
@@ -16,8 +16,8 @@ class FFmpegReaderStreamRTCustom(FFmpegReader):  # type: ignore[misc]
         stream_url: str,
         codec: Optional[str],
         pix_fmt: str,
-        crop_xywh: Optional[Tuple[int, int, int, int]],
-        resize: Optional[Tuple[int, int]],
+        crop_xywh: Optional[tuple[int, int, int, int]],
+        resize: Optional[tuple[int, int]],
         resize_keepratio: bool,
         resize_keepratioalign: str,
         timeout: Optional[int],
@@ -56,8 +56,8 @@ def FFmpegReaderStreamRTCustomInit(
     stream_url: str,
     codec: Optional[str] = None,
     pix_fmt: str = "bgr24",
-    crop_xywh: Optional[Tuple[int, int, int, int]] = None,
-    resize: Optional[Tuple[int, int]] = None,
+    crop_xywh: Optional[tuple[int, int, int, int]] = None,
+    resize: Optional[tuple[int, int]] = None,
     resize_keepratio: bool = True,
     resize_keepratioalign: str = "center",
     timeout: Optional[int] = None,

--- a/bot/camera.py
+++ b/bot/camera.py
@@ -11,7 +11,7 @@ import pickle
 import subprocess
 import threading
 import time
-from typing import Any, Callable, List, Optional, Tuple, TypeVar, cast
+from typing import Any, Callable, Optional, TypeVar, cast
 
 from assets.ffmpegcv_custom import FFmpegReaderStreamRTCustomInit
 import ffmpegcv  # type: ignore[import-untyped]
@@ -158,7 +158,7 @@ class Camera:
 
             # Todo: write this back or remove useless code
             # self._cv2_params: List = config.camera.cv2_params
-            self._cv2_params: List[Any] = []
+            self._cv2_params: list[Any] = []
             cv2.setNumThreads(self._threads)
             self.cam_cam = cv2.VideoCapture()
             self._set_cv2_params()
@@ -353,7 +353,7 @@ class Camera:
         return bio
 
     @cam_light_toggle
-    def take_video(self) -> Tuple[BytesIO, BytesIO, int, int]:
+    def take_video(self) -> tuple[BytesIO, BytesIO, int, int]:
         def process_video_frame(frame_local: NDArray[Any]) -> NDArray[Any]:
             if self._flip_vertically:
                 frame_local = np.flipud(frame_local)
@@ -465,7 +465,7 @@ class Camera:
 
         del raw_frame_rgb
 
-    async def create_timelapse(self, printing_filename: str, gcode_name: str, info_mess: Message) -> Tuple[bytes, bytes, int, int, str, str]:
+    async def create_timelapse(self, printing_filename: str, gcode_name: str, info_mess: Message) -> tuple[bytes, bytes, int, int, str, str]:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, functools.partial(self._create_timelapse, printing_filename, gcode_name, info_mess, loop))
 
@@ -491,7 +491,7 @@ class Camera:
     def _get_frame(self, path: Path) -> NDArray[Any]:
         return cast("NDArray[Any]", np.load(path, allow_pickle=True)["raw"])
 
-    def _create_timelapse(self, printing_filename: str, gcode_name: str, info_mess: Message, loop: asyncio.AbstractEventLoop) -> Tuple[bytes, bytes, int, int, str, str]:
+    def _create_timelapse(self, printing_filename: str, gcode_name: str, info_mess: Message, loop: asyncio.AbstractEventLoop) -> tuple[bytes, bytes, int, int, str, str]:
         if not printing_filename:
             raise ValueError("Gcode file name is empty")  # noqa: TRY003
 
@@ -609,7 +609,7 @@ class Camera:
     # Todo: check if lapse was in subfolder ( alike gcode folders)
     # Todo: refactor into timelapse class
     # Todo: check for 64 symbols length in lapse names
-    def detect_unfinished_lapses(self) -> List[str]:
+    def detect_unfinished_lapses(self) -> list[str]:
         # Todo: detect unstarted timelapse builds? folder with pics and no mp4 files
         return [el.parent.name for el in self._base_dir.rglob("*.lock")]
 
@@ -722,7 +722,7 @@ class MjpegCamera(Camera):
             return res
 
     @cam_light_toggle
-    def take_video(self) -> Tuple[BytesIO, BytesIO, int, int]:
+    def take_video(self) -> tuple[BytesIO, BytesIO, int, int]:
 
         with self._camera_lock:
             os_nice(15)
@@ -789,7 +789,7 @@ class RawStreamCamera(MjpegCamera):
             logger.warning("raw_stream camera: flip/rotate not supported for video (stream copy). Use type=ffmpeg if you need video transforms.")
 
     @cam_light_toggle
-    def take_video(self) -> Tuple[BytesIO, BytesIO, int, int]:
+    def take_video(self) -> tuple[BytesIO, BytesIO, int, int]:
         with self._camera_lock:
             os_nice(15)
 

--- a/bot/camera.py
+++ b/bot/camera.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import functools
@@ -11,7 +13,7 @@ import pickle
 import subprocess
 import threading
 import time
-from typing import Any, Callable, Optional, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
 
 from assets.ffmpegcv_custom import FFmpegReaderStreamRTCustomInit
 import ffmpegcv  # type: ignore[import-untyped]
@@ -20,12 +22,14 @@ from ffmpegcv.stream_info import get_info  # type: ignore[import-untyped]
 import httpx
 from httpx import HTTPError
 import numpy as np
-from numpy.typing import NDArray
 from PIL import Image, _webp
-from telegram import Message
 
-from configuration import ConfigWrapper
-from klippy import Klippy, PowerDevice
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+    from telegram import Message
+
+    from configuration import ConfigWrapper
+    from klippy import Klippy, PowerDevice
 
 try:
     import cv2
@@ -96,7 +100,7 @@ class Camera:
 
         # Todo: refactor into timelapse class
         self._base_dir: Path = config.timelapse.base_dir
-        self._ready_dir: Optional[Path] = config.timelapse.ready_dir
+        self._ready_dir: Path | None = config.timelapse.ready_dir
         self._cleanup: bool = config.timelapse.cleanup
 
         self._target_fps: int = 15
@@ -109,7 +113,7 @@ class Camera:
         self._light_need_off_lock: threading.Lock = threading.Lock()
 
         self.light_timeout: int = config.camera.light_timeout
-        self.light_device: Optional[PowerDevice] = self._klippy.light_device
+        self.light_device: PowerDevice | None = self._klippy.light_device
         self._camera_lock: threading.Lock = threading.Lock()
         self.light_lock = threading.Lock()
         self.light_timer_event: threading.Event = threading.Event()
@@ -325,7 +329,7 @@ class Camera:
 
         return cast("NDArray[Any]", ndaarr)
 
-    def take_photo(self, ndarr: Optional[NDArray[Any]] = None) -> BytesIO:
+    def take_photo(self, ndarr: NDArray[Any] | None = None) -> BytesIO:
         img = Image.fromarray(ndarr) if ndarr is not None else Image.fromarray(self._take_raw_frame())
 
         os_nice(15)
@@ -659,7 +663,7 @@ class MjpegCamera(Camera):
         return img
 
     @cam_light_toggle
-    def take_photo(self, ndarr: Optional[NDArray[Any]] = None, force_rotate: bool = True) -> BytesIO:
+    def take_photo(self, ndarr: NDArray[Any] | None = None, force_rotate: bool = True) -> BytesIO:
         bio = BytesIO()
         os_nice(15)
         try:

--- a/bot/camera.py
+++ b/bot/camera.py
@@ -483,14 +483,13 @@ class Camera:
             or (actual_duration > self._min_lapse_duration and self._max_lapse_duration == 0)
         ):
             return self._target_fps
-        elif actual_duration < self._min_lapse_duration and self._min_lapse_duration > 0:
+        if actual_duration < self._min_lapse_duration and self._min_lapse_duration > 0:
             fps = math.ceil(frames_count / self._min_lapse_duration)
             return max(fps, 1)
-        elif actual_duration > self._max_lapse_duration > 0:
+        if actual_duration > self._max_lapse_duration > 0:
             return math.ceil(frames_count / self._max_lapse_duration)
-        else:
-            logger.error("Unknown fps calculation state for durations min:%s and max:%s and actual:%s", self._min_lapse_duration, self._max_lapse_duration, actual_duration)
-            return self._target_fps
+        logger.error("Unknown fps calculation state for durations min:%s and max:%s and actual:%s", self._min_lapse_duration, self._max_lapse_duration, actual_duration)
+        return self._target_fps
 
     def _get_frame(self, path: Path) -> NDArray[Any]:
         return cast("NDArray[Any]", np.load(path, allow_pickle=True)["raw"])
@@ -663,7 +662,7 @@ class MjpegCamera(Camera):
         return img
 
     @cam_light_toggle
-    def take_photo(self, ndarr: NDArray[Any] | None = None, force_rotate: bool = True) -> BytesIO:
+    def take_photo(self, ndarr: NDArray[Any] | None = None, force_rotate: bool = True) -> BytesIO:  # noqa: ARG002
         bio = BytesIO()
         os_nice(15)
         try:

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -2,16 +2,16 @@ import configparser
 import copy
 from pathlib import Path
 import re
-from typing import Any, Callable, ClassVar, Final, List, Optional, Tuple, Union
+from typing import Any, Callable, ClassVar, Final, Optional, Union
 
 
 class ConfigHelper:
     _section: str
-    _KNOWN_ITEMS: ClassVar[List[str]]
+    _KNOWN_ITEMS: ClassVar[list[str]]
 
     def __init__(self, config: configparser.ConfigParser):
         self._config = config
-        self._parsing_errors: List[str] = []
+        self._parsing_errors: list[str] = []
 
     @property
     def unknown_fields(self) -> str:
@@ -53,13 +53,13 @@ class ConfigHelper:
         if max_value is not None and value > max_value:
             self._parsing_errors.append(f"Option '{option}: {value}': value is above maximum value {max_value}")
 
-    def _check_string_values(self, option: str, value: str, allowed_values: Optional[List[str]] = None) -> None:
+    def _check_string_values(self, option: str, value: str, allowed_values: Optional[list[str]] = None) -> None:
         if not self._config.has_option(self._section, option):
             return
         if allowed_values is not None and value not in allowed_values:
             self._parsing_errors.append(f"Option '{option}: {value}': value '{value}' is not allowed")
 
-    def _check_list_values(self, option: str, values: List[Any], allowed_values: Optional[List[Any]] = None) -> None:
+    def _check_list_values(self, option: str, values: list[Any], allowed_values: Optional[list[Any]] = None) -> None:
         if not self._config.has_option(self._section, option):
             return
         unallowed_params = [val for val in values if val not in allowed_values] if allowed_values is not None else []
@@ -103,7 +103,7 @@ class ConfigHelper:
         self._check_numerical_value(option, val, above, below, min_value, max_value)
         return val
 
-    def _get_str(self, option: str, default: Optional[str] = None, allowed_values: Optional[List[Any]] = None) -> str:
+    def _get_str(self, option: str, default: Optional[str] = None, allowed_values: Optional[list[Any]] = None) -> str:
         val: str = self._get_option_value(self._config.get, option, default)
         self._check_string_values(option, val, allowed_values)
         return val
@@ -112,7 +112,7 @@ class ConfigHelper:
         val: bool = self._get_option_value(self._config.getboolean, option, default)
         return val
 
-    def _get_list(self, option: str, default: Optional[List[Any]] = None, el_type: Any = str, allowed_values: Optional[List[Any]] = None) -> List[Any]:
+    def _get_list(self, option: str, default: Optional[list[Any]] = None, el_type: Any = str, allowed_values: Optional[list[Any]] = None) -> list[Any]:
         if self._config.has_option(self._section, option):
             try:
                 val = [el_type(el.strip()) for el in self._get_str(option).split(",")]
@@ -135,7 +135,7 @@ class ConfigHelper:
 
 class SecretsConfig(ConfigHelper):
     _section = "secrets"
-    _KNOWN_ITEMS: ClassVar[List[str]] = [
+    _KNOWN_ITEMS: ClassVar[list[str]] = [
         "bot_token",
         "chat_id",
         "user",
@@ -169,7 +169,7 @@ class SecretsConfig(ConfigHelper):
 
 class BotConfig(ConfigHelper):
     _section = "bot"
-    _KNOWN_ITEMS: ClassVar[List[str]] = [
+    _KNOWN_ITEMS: ClassVar[list[str]] = [
         "bot_token",
         "chat_id",
         "user",
@@ -206,7 +206,7 @@ class BotConfig(ConfigHelper):
         self.log_path: Path = Path(self._get_str("log_path", default="/tmp"))
         self.log_file: Path = Path(self._get_str("log_path", default="/tmp"))
         self.upload_path: str = self._get_str("upload_path", default="")
-        self.services: List[str] = self._get_list("services", default=["klipper", "moonraker"])
+        self.services: list[str] = self._get_list("services", default=["klipper", "moonraker"])
         self.log_parser: bool = self._get_boolean("log_parser", default=False)
 
         host_parts = self.host.split(":")
@@ -237,7 +237,7 @@ class BotConfig(ConfigHelper):
 
 class CameraConfig(ConfigHelper):
     _section = "camera"
-    _KNOWN_ITEMS: ClassVar[List[str]] = [
+    _KNOWN_ITEMS: ClassVar[list[str]] = [
         "host",
         "host_snapshot",
         "threads",
@@ -276,7 +276,7 @@ class CameraConfig(ConfigHelper):
 
 class NotifierConfig(ConfigHelper):
     _section = "progress_notification"
-    _KNOWN_ITEMS: ClassVar[List[str]] = ["percent", "height", "time", "groups", "group_only"]
+    _KNOWN_ITEMS: ClassVar[list[str]] = ["percent", "height", "time", "groups", "group_only"]
 
     def __init__(self, config: configparser.ConfigParser):
         super().__init__(config)
@@ -284,14 +284,14 @@ class NotifierConfig(ConfigHelper):
         self.percent: int = self._get_int("percent", default=0, min_value=0)
         self.height: float = self._get_float("height", default=0, min_value=0.0)
         self.interval: int = self._get_int("time", default=0, min_value=0)
-        self.notify_groups: List[Tuple[int, Optional[int]]] = self._get_groups_list()
+        self.notify_groups: list[tuple[int, Optional[int]]] = self._get_groups_list()
         self.group_only: bool = self._get_boolean("group_only", default=False)
 
-    def _get_groups_list(self) -> List[Tuple[int, Optional[int]]]:
+    def _get_groups_list(self) -> list[tuple[int, Optional[int]]]:
         els = [self._get_group_with_thread_id(el) for el in self._get_list("groups", default=[], el_type=str)]
         return [ell for ell in els if ell is not None]
 
-    def _get_group_with_thread_id(self, group_id: str) -> Optional[Tuple[int, Optional[int]]]:
+    def _get_group_with_thread_id(self, group_id: str) -> Optional[tuple[int, Optional[int]]]:
         try:
             parts = group_id.split(":")
             if len(parts) == 2:
@@ -308,7 +308,7 @@ class NotifierConfig(ConfigHelper):
 
 class TimelapseConfig(ConfigHelper):
     _section = "timelapse"
-    _KNOWN_ITEMS: ClassVar[List[str]] = [
+    _KNOWN_ITEMS: ClassVar[list[str]] = [
         "basedir",
         "copy_finished_timelapse_dir",
         "cleanup",
@@ -359,7 +359,7 @@ class TimelapseConfig(ConfigHelper):
 
 class TelegramUIConfig(ConfigHelper):
     _section = "telegram_ui"
-    _KNOWN_ITEMS: ClassVar[List[str]] = [
+    _KNOWN_ITEMS: ClassVar[list[str]] = [
         "silent_progress",
         "silent_commands",
         "silent_status",
@@ -394,7 +394,7 @@ class TelegramUIConfig(ConfigHelper):
         super().__init__(config)
         self.eta_source: str = self._get_str("eta_source", default="slicer", allowed_values=["slicer", "file"])
         self.buttons_default: bool = bool(not config.has_option(self._section, "buttons"))
-        self.buttons: List[List[str]] = list(  # noqa: C417
+        self.buttons: list[list[str]] = list(  # noqa: C417
             map(
                 lambda el: list(  # noqa: C417
                     map(
@@ -411,14 +411,14 @@ class TelegramUIConfig(ConfigHelper):
         self.silent_commands: bool = self._get_boolean("silent_commands", default=False)
         self.silent_status: bool = self._get_boolean("silent_status", default=False)
         self.include_macros_in_command_list: bool = self._get_boolean("include_macros_in_command_list", default=True)
-        self.hidden_macros: List[str] = [el.upper() for el in self._get_list("hidden_macros", default=[])]
-        self.hidden_bot_commands: List[str] = self._get_list("hidden_bot_commands", default=[])
+        self.hidden_macros: list[str] = [el.upper() for el in self._get_list("hidden_macros", default=[])]
+        self.hidden_bot_commands: list[str] = self._get_list("hidden_bot_commands", default=[])
         self.show_private_macros: bool = self._get_boolean("show_private_macros", default=False)
         self.pin_status_single_message: bool = self._get_boolean("pin_status_single_message", default=True)
         self.status_message_m117_update: bool = self._get_boolean("status_message_m117_update", default=False)
         self.send_greeting_message: bool = self._get_boolean("send_greeting_message", default=True)
         self.status_update_button: bool = self._get_boolean("status_update_button", default=True)
-        self.require_confirmation: List[str] = self._get_list(
+        self.require_confirmation: list[str] = self._get_list(
             "require_confirmation", default=["logs", "logs_upload", "shutdown", "restart", "cancel", "fw_restart", "emergency", "reboot", "power", "bot_restart"]
         )
 
@@ -437,7 +437,7 @@ class TelegramUIConfig(ConfigHelper):
 
 class StatusMessageContentConfig(ConfigHelper):
     _section = "status_message_content"
-    _KNOWN_ITEMS: ClassVar[List[str]] = ["content", "sensors", "heaters", "fans", "moonraker_devices"]
+    _KNOWN_ITEMS: ClassVar[list[str]] = ["content", "sensors", "heaters", "fans", "moonraker_devices"]
     _MESSAGE_CONTENT: Final = [
         "progress",
         "height",
@@ -453,11 +453,11 @@ class StatusMessageContentConfig(ConfigHelper):
 
     def __init__(self, config: configparser.ConfigParser):
         super().__init__(config)
-        self.content: List[str] = self._get_list("content", default=self._MESSAGE_CONTENT, allowed_values=self._MESSAGE_CONTENT)
-        self.sensors: List[str] = self._get_list("sensors", default=[])
-        self.heaters: List[str] = self._get_list("heaters", default=[])
-        self.fans: List[str] = self._get_list("fans", default=[])
-        self.moonraker_devices: List[str] = self._get_list("moonraker_devices", default=[])
+        self.content: list[str] = self._get_list("content", default=self._MESSAGE_CONTENT, allowed_values=self._MESSAGE_CONTENT)
+        self.sensors: list[str] = self._get_list("sensors", default=[])
+        self.heaters: list[str] = self._get_list("heaters", default=[])
+        self.fans: list[str] = self._get_list("fans", default=[])
+        self.moonraker_devices: list[str] = self._get_list("moonraker_devices", default=[])
 
 
 class ConfigWrapper:

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -23,8 +23,7 @@ class ConfigHelper:
     def parsing_errors(self) -> str:
         if self._parsing_errors:
             return f"Config errors in section [{self._section}]:\n  " + "\n  ".join(self._parsing_errors) + "\n"
-        else:
-            return ""
+        return ""
 
     def _check_config(self) -> str:
         if not self._config.has_section(self._section):
@@ -32,8 +31,7 @@ class ConfigHelper:
         unknown = [f"  {fil[0]}: {fil[1]}\n" for fil in self._config.items(self._section) if fil[0] not in self._KNOWN_ITEMS]
         if unknown:
             return f"Unknown/bad items in section [{self._section}]:\n{''.join(unknown)}\n"
-        else:
-            return ""
+        return ""
 
     def _check_numerical_value(
         self,
@@ -224,8 +222,7 @@ class BotConfig(ConfigHelper):
             return ""
         if not self.upload_path.endswith("/"):
             return self.upload_path + "/"
-        else:
-            return self.upload_path
+        return self.upload_path
 
     def log_path_update(self, logfile: str) -> None:
         if logfile:
@@ -298,11 +295,10 @@ class NotifierConfig(ConfigHelper):
             parts = group_id.split(":")
             if len(parts) == 2:
                 return int(parts[0]), int(parts[1])
-            elif len(parts) == 1:
+            if len(parts) == 1:
                 return int(parts[0]), None
-            else:
-                self._parsing_errors.append(f"Malformed group_id `{group_id}`")
-                return None
+            self._parsing_errors.append(f"Malformed group_id `{group_id}`")
+            return None  # noqa: TRY300
         except Exception as ex:
             self._parsing_errors.append(f"Error parsing group_id `{group_id}` \n {ex}")
             return None

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import configparser
 import copy
 from pathlib import Path
 import re
-from typing import Any, Callable, ClassVar, Final, Optional, Union
+from typing import Any, Callable, ClassVar, Final
 
 
 class ConfigHelper:
@@ -36,11 +38,11 @@ class ConfigHelper:
     def _check_numerical_value(
         self,
         option: str,
-        value: Union[int, float],
-        above: Optional[Union[int, float]] = None,
-        below: Optional[Union[int, float]] = None,
-        min_value: Optional[Union[int, float]] = None,
-        max_value: Optional[Union[int, float]] = None,
+        value: int | float,
+        above: int | float | None = None,
+        below: int | float | None = None,
+        min_value: int | float | None = None,
+        max_value: int | float | None = None,
     ) -> None:
         if not self._config.has_option(self._section, option):
             return
@@ -53,20 +55,20 @@ class ConfigHelper:
         if max_value is not None and value > max_value:
             self._parsing_errors.append(f"Option '{option}: {value}': value is above maximum value {max_value}")
 
-    def _check_string_values(self, option: str, value: str, allowed_values: Optional[list[str]] = None) -> None:
+    def _check_string_values(self, option: str, value: str, allowed_values: list[str] | None = None) -> None:
         if not self._config.has_option(self._section, option):
             return
         if allowed_values is not None and value not in allowed_values:
             self._parsing_errors.append(f"Option '{option}: {value}': value '{value}' is not allowed")
 
-    def _check_list_values(self, option: str, values: list[Any], allowed_values: Optional[list[Any]] = None) -> None:
+    def _check_list_values(self, option: str, values: list[Any], allowed_values: list[Any] | None = None) -> None:
         if not self._config.has_option(self._section, option):
             return
         unallowed_params = [val for val in values if val not in allowed_values] if allowed_values is not None else []
         if unallowed_params:
             self._parsing_errors.append(f"Option '{option}: {values}': values [" + ",".join(unallowed_params) + "] are not allowed")
 
-    def _get_option_value(self, func: Callable[..., Any], option: str, default: Optional[Any] = None) -> Any:
+    def _get_option_value(self, func: Callable[..., Any], option: str, default: Any | None = None) -> Any:
         try:
             val = func(self._section, option, fallback=default) if default is not None else func(self._section, option)
         except Exception as ex:
@@ -80,11 +82,11 @@ class ConfigHelper:
     def _get_int(
         self,
         option: str,
-        default: Optional[int] = None,
-        above: Optional[Union[int, float]] = None,
-        below: Optional[Union[int, float]] = None,
-        min_value: Optional[Union[int, float]] = None,
-        max_value: Optional[Union[int, float]] = None,
+        default: int | None = None,
+        above: int | float | None = None,
+        below: int | float | None = None,
+        min_value: int | float | None = None,
+        max_value: int | float | None = None,
     ) -> int:
         val: int = self._get_option_value(self._config.getint, option, default)
         self._check_numerical_value(option, val, above, below, min_value, max_value)
@@ -93,26 +95,26 @@ class ConfigHelper:
     def _get_float(
         self,
         option: str,
-        default: Optional[float] = None,
-        above: Optional[Union[int, float]] = None,
-        below: Optional[Union[int, float]] = None,
-        min_value: Optional[Union[int, float]] = None,
-        max_value: Optional[Union[int, float]] = None,
+        default: float | None = None,
+        above: int | float | None = None,
+        below: int | float | None = None,
+        min_value: int | float | None = None,
+        max_value: int | float | None = None,
     ) -> float:
         val: float = self._get_option_value(self._config.getfloat, option, default)
         self._check_numerical_value(option, val, above, below, min_value, max_value)
         return val
 
-    def _get_str(self, option: str, default: Optional[str] = None, allowed_values: Optional[list[Any]] = None) -> str:
+    def _get_str(self, option: str, default: str | None = None, allowed_values: list[Any] | None = None) -> str:
         val: str = self._get_option_value(self._config.get, option, default)
         self._check_string_values(option, val, allowed_values)
         return val
 
-    def _get_boolean(self, option: str, default: Optional[bool] = None) -> bool:
+    def _get_boolean(self, option: str, default: bool | None = None) -> bool:
         val: bool = self._get_option_value(self._config.getboolean, option, default)
         return val
 
-    def _get_list(self, option: str, default: Optional[list[Any]] = None, el_type: Any = str, allowed_values: Optional[list[Any]] = None) -> list[Any]:
+    def _get_list(self, option: str, default: list[Any] | None = None, el_type: Any = str, allowed_values: list[Any] | None = None) -> list[Any]:
         if self._config.has_option(self._section, option):
             try:
                 val = [el_type(el.strip()) for el in self._get_str(option).split(",")]
@@ -284,14 +286,14 @@ class NotifierConfig(ConfigHelper):
         self.percent: int = self._get_int("percent", default=0, min_value=0)
         self.height: float = self._get_float("height", default=0, min_value=0.0)
         self.interval: int = self._get_int("time", default=0, min_value=0)
-        self.notify_groups: list[tuple[int, Optional[int]]] = self._get_groups_list()
+        self.notify_groups: list[tuple[int, int | None]] = self._get_groups_list()
         self.group_only: bool = self._get_boolean("group_only", default=False)
 
-    def _get_groups_list(self) -> list[tuple[int, Optional[int]]]:
+    def _get_groups_list(self) -> list[tuple[int, int | None]]:
         els = [self._get_group_with_thread_id(el) for el in self._get_list("groups", default=[], el_type=str)]
         return [ell for ell in els if ell is not None]
 
-    def _get_group_with_thread_id(self, group_id: str) -> Optional[tuple[int, Optional[int]]]:
+    def _get_group_with_thread_id(self, group_id: str) -> tuple[int, int | None] | None:
         try:
             parts = group_id.split(":")
             if len(parts) == 2:
@@ -332,7 +334,7 @@ class TimelapseConfig(ConfigHelper):
         self.enabled: bool = config.has_section(self._section)
         self.base_dir: Path = Path(self._get_str("basedir", default="~/moonraker-telegram-bot-timelapse"))
         _ready_dir = self._get_str("copy_finished_timelapse_dir", default="")
-        self.ready_dir: Optional[Path] = Path(_ready_dir) if _ready_dir else None
+        self.ready_dir: Path | None = Path(_ready_dir) if _ready_dir else None
         self.cleanup: bool = self._get_boolean("cleanup", default=True)
         self.height: float = self._get_float("height", default=0.0, min_value=0.0)
         self.interval: int = self._get_int("time", default=0, min_value=0)

--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -7,7 +7,7 @@ from io import BytesIO
 import logging
 import re
 import time
-from typing import Any, Dict, Final, List, Optional, Tuple, TypeVar
+from typing import Any, Final, Optional, TypeVar
 import urllib
 
 import emoji
@@ -96,17 +96,17 @@ class Klippy:
         self._protocol: str = "https" if config.bot_config.ssl else "http"
         self._host: str = f"{self._protocol}://{config.bot_config.host}:{config.bot_config.port}"
         self._ssl_verify: bool = config.bot_config.ssl_verify
-        self._hidden_macros: List[str] = [*config.telegram_ui.hidden_macros, self._DATA_MACRO]
+        self._hidden_macros: list[str] = [*config.telegram_ui.hidden_macros, self._DATA_MACRO]
         self._show_private_macros: bool = config.telegram_ui.show_private_macros
-        self._message_parts: List[str] = config.status_message_content.content
+        self._message_parts: list[str] = config.status_message_content.content
         self._eta_source: str = config.telegram_ui.eta_source
         self._light_device: Optional[PowerDevice]
         self._psu_device: Optional[PowerDevice]
-        self._sensors_list: List[str] = config.status_message_content.sensors
-        self._heaters_list: List[str] = config.status_message_content.heaters
-        self._fans_list: List[str] = config.status_message_content.fans
+        self._sensors_list: list[str] = config.status_message_content.sensors
+        self._heaters_list: list[str] = config.status_message_content.heaters
+        self._fans_list: list[str] = config.status_message_content.fans
 
-        self._devices_list: List[str] = config.status_message_content.moonraker_devices
+        self._devices_list: list[str] = config.status_message_content.moonraker_devices
         self._user: str = config.secrets.user
         self._passwd: str = config.secrets.passwd
         self._api_token: str = config.secrets.api_token
@@ -138,7 +138,7 @@ class Klippy:
 
         # Todo: create sensors class!!
         self._objects_list: list[str] = []
-        self._sensors_dict: dict[str, Dict[str, Any]] = {}
+        self._sensors_dict: dict[str, dict[str, Any]] = {}
         self._power_devices: dict[str, Any] = {}
 
         if logging_handler:
@@ -157,9 +157,9 @@ class Klippy:
         assert self._loop is not None, "Event loop not set. Call async_init() first."
         return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
 
-    def prepare_sens_dict_subscribe(self) -> Dict[str, Any]:
+    def prepare_sens_dict_subscribe(self) -> dict[str, Any]:
         self._sensors_dict = {}
-        sens_dict: Dict[str, Any] = {}
+        sens_dict: dict[str, Any] = {}
 
         for elem in self._objects_list:
             for heat in self._heaters_list:
@@ -209,10 +209,10 @@ class Klippy:
 
     # Todo: save macros list until klippy restart
     @property
-    def macros(self) -> List[str]:
+    def macros(self) -> list[str]:
         return self._get_marco_list()
 
-    async def get_macros_force(self) -> List[str]:
+    async def get_macros_force(self) -> list[str]:
         try:
             await self._update_printer_objects()
         except Exception:
@@ -220,7 +220,7 @@ class Klippy:
         return self._get_marco_list()
 
     @property
-    def macros_all(self) -> List[str]:
+    def macros_all(self) -> list[str]:
         return self._get_full_marco_list()
 
     @property
@@ -228,7 +228,7 @@ class Klippy:
         return self._host
 
     @property
-    def _headers(self) -> Dict[str, str]:
+    def _headers(self) -> dict[str, str]:
         heads = {}
         if self._jwt_token:
             heads = {"Authorization": f"Bearer {self._jwt_token}"}
@@ -315,12 +315,12 @@ class Klippy:
     def printing_filename_with_time(self) -> str:
         return f"{self._printing_filename}_{datetime.fromtimestamp(self.file_print_start_time):%Y-%m-%d_%H-%M}"
 
-    def _get_full_marco_list(self) -> List[str]:
+    def _get_full_marco_list(self) -> list[str]:
         macro_lines = list(filter(lambda it: "gcode_macro" in it, self._objects_list))
         loaded_macros = [el.split(" ")[1].upper() for el in macro_lines]
         return loaded_macros
 
-    def _get_marco_list(self) -> List[str]:
+    def _get_marco_list(self) -> list[str]:
         return [key for key in self._get_full_marco_list() if key not in self._hidden_macros and (True if self._show_private_macros else not key.startswith("_"))]
 
     async def _auth_moonraker(self) -> None:
@@ -384,7 +384,7 @@ class Klippy:
             await asyncio.sleep(1)
         return f"Connection failed. {last_reason}"
 
-    def update_sensor(self, name: str, value: Dict[str, Any]) -> None:
+    def update_sensor(self, name: str, value: dict[str, Any]) -> None:
         if name not in self._sensors_dict:
             self._sensors_dict[name] = {}
         for key, val in self._SENSOR_PARAMS.items():
@@ -392,7 +392,7 @@ class Klippy:
                 self._sensors_dict[name][key] = value[val]
 
     @staticmethod
-    def _sensor_message(name: str, value: Dict[str, Any]) -> str:
+    def _sensor_message(name: str, value: dict[str, Any]) -> str:
         sens_name = re.sub(r"([A-Z]|\d|_)", r" \1", name).replace("_", "")
         message = ""
 
@@ -418,7 +418,7 @@ class Klippy:
 
         return message
 
-    def update_power_device(self, name: str, value: Dict[str, Any]) -> None:
+    def update_power_device(self, name: str, value: dict[str, Any]) -> None:
         if name not in self._power_devices:
             self._power_devices[name] = {}
         for key, val in self._POWER_DEVICE_PARAMS.items():
@@ -426,7 +426,7 @@ class Klippy:
                 self._power_devices[name][key] = value[val]
 
     @staticmethod
-    def _device_message(name: str, value: Dict[str, Any], emoji_symbol: str = ":vertical_traffic_light:") -> str:
+    def _device_message(name: str, value: dict[str, Any], emoji_symbol: str = ":vertical_traffic_light:") -> str:
         message = emoji.emojize(f" {emoji_symbol} ", language="alias") + f"{name}: "
         if "status" in value:
             message += f" {value['status']} "
@@ -470,7 +470,7 @@ class Klippy:
         eta = max(eta, 0)
         return timedelta(seconds=eta)
 
-    async def _populate_with_thumb(self, thumb_path: str, message: str) -> Tuple[str, BytesIO]:
+    async def _populate_with_thumb(self, thumb_path: str, message: str) -> tuple[str, BytesIO]:
         if not thumb_path:
             img = Image.open("../imgs/nopreview.png").convert("RGB")
             logger.warning("Empty thumbnail_path")
@@ -490,7 +490,7 @@ class Klippy:
         img.close()
         return message, bio
 
-    async def get_file_info(self, state: PrintState = PrintState.PRINTING) -> Tuple[str, BytesIO]:
+    async def get_file_info(self, state: PrintState = PrintState.PRINTING) -> tuple[str, BytesIO]:
         message = self.get_print_stats(state=state)
         return await self._populate_with_thumb(self._thumbnail_path, message)
 
@@ -587,7 +587,7 @@ class Klippy:
 
         return message
 
-    async def get_file_info_by_name(self, filename: str, message: str) -> Tuple[str, BytesIO]:
+    async def get_file_info_by_name(self, filename: str, message: str) -> tuple[str, BytesIO]:
         resp = orjson.loads((await self.make_request("GET", f"/server/files/metadata?filename={urllib.parse.quote(filename)}")).text)["result"]
         message += "\n"
         if "filament_total" in resp and resp["filament_total"] > 0.0:
@@ -610,7 +610,7 @@ class Klippy:
 
         return await self._populate_with_thumb(thumb_path, message)
 
-    async def get_gcode_files(self) -> List[Dict[str, Any]]:
+    async def get_gcode_files(self) -> list[dict[str, Any]]:
         response = await self.make_request("GET", "/server/files/list?root=gcodes")
         files = sorted(orjson.loads(response.text)["result"], key=lambda item: item["modified"], reverse=True)
         return files

--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -321,8 +321,7 @@ class Klippy:
 
     def _get_full_marco_list(self) -> list[str]:
         macro_lines = list(filter(lambda it: "gcode_macro" in it, self._objects_list))
-        loaded_macros = [el.split(" ")[1].upper() for el in macro_lines]
-        return loaded_macros
+        return [el.split(" ")[1].upper() for el in macro_lines]
 
     def _get_marco_list(self) -> list[str]:
         return [key for key in self._get_full_marco_list() if key not in self._hidden_macros and (True if self._show_private_macros else not key.startswith("_"))]
@@ -378,9 +377,8 @@ class Klippy:
 
                 if connected:
                     return ""
-                else:
-                    # Todo: get reason from error handler
-                    last_reason = f"{response.status_code}"
+                # Todo: get reason from error handler
+                last_reason = f"{response.status_code}"
             except Exception:
                 logger.exception("Failed to check connection")
 
@@ -616,8 +614,7 @@ class Klippy:
 
     async def get_gcode_files(self) -> list[dict[str, Any]]:
         response = await self.make_request("GET", "/server/files/list?root=gcodes")
-        files = sorted(orjson.loads(response.text)["result"], key=lambda item: item["modified"], reverse=True)
-        return files
+        return sorted(orjson.loads(response.text)["result"], key=lambda item: item["modified"], reverse=True)
 
     async def upload_gcode_file(self, file: BytesIO, upload_path: str) -> bool:
         return (await self.make_request("POST", "/server/files/upload", files={"file": file, "root": "gcodes", "path": upload_path})).is_success
@@ -660,10 +657,9 @@ class Klippy:
         res = await self.make_request("GET", f"/server/database/item?namespace={self._dbname}&key={param_name}")
         if res.is_success:
             return orjson.loads(res.text)["result"]["value"]
-        else:
-            logger.error("Failed getting %s from %s \n\n%s", param_name, self._dbname, res)
-            # Fixme: return default value? check for 404!
-            return None
+        logger.error("Failed getting %s from %s \n\n%s", param_name, self._dbname, res)
+        # Fixme: return default value? check for 404!
+        return None
 
     async def save_param_to_db(self, param_name: str, value: Any) -> None:
         data = {"namespace": self._dbname, "key": param_name, "value": value}

--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -1,13 +1,14 @@
 # Todo: class for printer states!
+from __future__ import annotations
+
 import asyncio
-from collections.abc import Coroutine
 from datetime import datetime, timedelta
 from enum import Enum
 from io import BytesIO
 import logging
 import re
 import time
-from typing import Any, Final, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Final, TypeVar
 import urllib
 
 import emoji
@@ -16,7 +17,10 @@ from httpx import AsyncClient
 import orjson
 from PIL import Image
 
-from configuration import ConfigWrapper
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
+
+    from configuration import ConfigWrapper
 
 T = TypeVar("T")
 
@@ -41,7 +45,7 @@ class PrintState(Enum):
 
 
 class PowerDevice:
-    def __init__(self, name: str, klippy_: "Klippy") -> None:
+    def __init__(self, name: str, klippy_: Klippy) -> None:
         self.name: str = name
         self._state_lock_async = asyncio.Lock()
         self._device_on: bool = False
@@ -100,8 +104,8 @@ class Klippy:
         self._show_private_macros: bool = config.telegram_ui.show_private_macros
         self._message_parts: list[str] = config.status_message_content.content
         self._eta_source: str = config.telegram_ui.eta_source
-        self._light_device: Optional[PowerDevice]
-        self._psu_device: Optional[PowerDevice]
+        self._light_device: PowerDevice | None
+        self._psu_device: PowerDevice | None
         self._sensors_list: list[str] = config.status_message_content.sensors
         self._heaters_list: list[str] = config.status_message_content.heaters
         self._fans_list: list[str] = config.status_message_content.fans
@@ -147,7 +151,7 @@ class Klippy:
             logger.setLevel(logging.DEBUG)
 
         self._client: AsyncClient = AsyncClient(verify=self._ssl_verify)
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._loop: asyncio.AbstractEventLoop | None = None
 
     async def async_init(self) -> None:
         self._loop = asyncio.get_running_loop()
@@ -178,19 +182,19 @@ class Klippy:
         return self.filament_weight * (self.filament_used / self.filament_total)
 
     @property
-    def psu_device(self) -> Optional[PowerDevice]:
+    def psu_device(self) -> PowerDevice | None:
         return self._psu_device
 
     @psu_device.setter
-    def psu_device(self, psu_device: Optional[PowerDevice]) -> None:
+    def psu_device(self, psu_device: PowerDevice | None) -> None:
         self._psu_device = psu_device
 
     @property
-    def light_device(self) -> Optional[PowerDevice]:
+    def light_device(self) -> PowerDevice | None:
         return self._light_device
 
     @light_device.setter
-    def light_device(self, light_device: Optional[PowerDevice]) -> None:
+    def light_device(self, light_device: PowerDevice | None) -> None:
         self._light_device = light_device
 
     @property

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import argparse
 import asyncio
-from collections.abc import Coroutine
 from concurrent.futures import ThreadPoolExecutor
 import contextlib
 import faulthandler
@@ -17,7 +18,7 @@ import socket
 import subprocess
 import sys
 import tarfile
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 from zipfile import ZipFile
 
 import aiofiles
@@ -53,6 +54,9 @@ from notifications import Notifier
 from telegram_helper import TelegramMessageRepr
 from timelapse import Timelapse
 from websocket_helper import WebSocketHelper
+
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
 
 with contextlib.suppress(ImportError):
     import uvloop
@@ -133,8 +137,8 @@ camera_wrap: Camera
 timelapse: Timelapse
 notifier: Notifier
 klippy: Klippy
-light_power_device: Optional[PowerDevice]
-psu_power_device: Optional[PowerDevice]
+light_power_device: PowerDevice | None
+psu_power_device: PowerDevice | None
 ws_helper: WebSocketHelper
 executors_pool: ThreadPoolExecutor = ThreadPoolExecutor(2, thread_name_prefix="bot_pool")
 
@@ -387,7 +391,7 @@ async def bot_restart(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
     await command_confirm_message_ext(update=update, command="bot_restart", confirm_text="Restart bot?", exec_text="Restarting bot", callback_mess="bot_restart", exec_func=restart_bot())
 
 
-def prepare_log_files() -> tuple[list[str], bool, Optional[str]]:
+def prepare_log_files() -> tuple[list[str], bool, str | None]:
     dmesg_success = True
     dmesg_error = None
     log_dir = config_wrap.bot_config.log_path
@@ -452,7 +456,7 @@ async def send_logs_no_confirm(effective_message: Message) -> None:
     )
 
     log_dir = config_wrap.bot_config.log_path
-    logs_list: list[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]] = []
+    logs_list: list[InputMediaAudio | InputMediaDocument | InputMediaPhoto | InputMediaVideo] = []
     for log_file in prepare_log_files()[0]:
         try:
             log_file_path = log_dir / log_file
@@ -1179,7 +1183,7 @@ async def help_command(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
         await help_command_no_confirm(update.effective_message)
 
 
-def prepare_command(marco: str) -> Optional[BotCommand]:
+def prepare_command(marco: str) -> BotCommand | None:
     if re.match("^[a-zA-Z0-9_]{1,32}$", marco):
         try:
             return BotCommand(marco.lower(), marco)

--- a/bot/main.py
+++ b/bot/main.py
@@ -17,7 +17,7 @@ import socket
 import subprocess
 import sys
 import tarfile
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 from zipfile import ZipFile
 
 import aiofiles
@@ -200,7 +200,7 @@ async def check_unfinished_lapses(bot: telegram.Bot) -> None:
     if not files:
         return
     await bot.send_chat_action(chat_id=config_wrap.secrets.chat_id, action=ChatAction.TYPING)
-    files_keys: List[List[InlineKeyboardButton]] = [[InlineKeyboardButton(text=el, callback_data=f"lapse:{hashlib.md5(el.encode()).hexdigest()}")] for el in files]
+    files_keys: list[list[InlineKeyboardButton]] = [[InlineKeyboardButton(text=el, callback_data=f"lapse:{hashlib.md5(el.encode()).hexdigest()}")] for el in files]
     files_keys.append(
         [
             InlineKeyboardButton(
@@ -387,7 +387,7 @@ async def bot_restart(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
     await command_confirm_message_ext(update=update, command="bot_restart", confirm_text="Restart bot?", exec_text="Restarting bot", callback_mess="bot_restart", exec_func=restart_bot())
 
 
-def prepare_log_files() -> tuple[List[str], bool, Optional[str]]:
+def prepare_log_files() -> tuple[list[str], bool, Optional[str]]:
     dmesg_success = True
     dmesg_error = None
     log_dir = config_wrap.bot_config.log_path
@@ -452,7 +452,7 @@ async def send_logs_no_confirm(effective_message: Message) -> None:
     )
 
     log_dir = config_wrap.bot_config.log_path
-    logs_list: List[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]] = []
+    logs_list: list[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]] = []
     for log_file in prepare_log_files()[0]:
         try:
             log_file_path = log_dir / log_file
@@ -843,7 +843,7 @@ async def get_gcode_files(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def gcode_files_keyboard(offset: int = 0) -> InlineKeyboardMarkup:
-    def create_file_button(element: Dict[str, Any]) -> List[InlineKeyboardButton]:
+    def create_file_button(element: dict[str, Any]) -> list[InlineKeyboardButton]:
         filename = element["path"] if "path" in element else element["filename"]
         return [
             InlineKeyboardButton(
@@ -853,7 +853,7 @@ async def gcode_files_keyboard(offset: int = 0) -> InlineKeyboardMarkup:
         ]
 
     gcodes = await klippy.get_gcode_files()
-    files_keys: List[List[InlineKeyboardButton]] = list(map(create_file_button, gcodes[offset : offset + 10]))
+    files_keys: list[list[InlineKeyboardButton]] = list(map(create_file_button, gcodes[offset : offset + 10]))
     if len(gcodes) > 10:
         arrows = []
         if offset >= 10:
@@ -883,7 +883,7 @@ async def gcode_files_keyboard(offset: int = 0) -> InlineKeyboardMarkup:
 
 
 async def services_keyboard_no_confirm(effective_message: Message) -> None:
-    def create_service_button(element: str) -> List[InlineKeyboardButton]:
+    def create_service_button(element: str) -> list[InlineKeyboardButton]:
         return [
             InlineKeyboardButton(
                 element,
@@ -892,7 +892,7 @@ async def services_keyboard_no_confirm(effective_message: Message) -> None:
         ]
 
     services = config_wrap.bot_config.services
-    service_keys: List[List[InlineKeyboardButton]] = list(map(create_service_button, services))
+    service_keys: list[list[InlineKeyboardButton]] = list(map(create_service_button, services))
 
     await effective_message.get_bot().send_chat_action(chat_id=config_wrap.secrets.chat_id, action=ChatAction.TYPING)
     await effective_message.reply_text(
@@ -932,7 +932,7 @@ async def exec_gcode(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
 
 async def get_macros_no_confirm(effective_message: Message) -> None:
     await effective_message.get_bot().send_chat_action(chat_id=config_wrap.secrets.chat_id, action=ChatAction.TYPING)
-    files_keys: List[List[InlineKeyboardButton]] = [
+    files_keys: list[list[InlineKeyboardButton]] = [
         [
             InlineKeyboardButton(
                 el,
@@ -1110,7 +1110,7 @@ def bot_error_handler(_: object, context: CallbackContext) -> None:  # type: ign
     logger.error(msg="Exception while handling an update:", exc_info=context.error)
 
 
-def create_keyboard() -> List[List[str]]:
+def create_keyboard() -> list[list[str]]:
     if not config_wrap.telegram_ui.buttons_default:
         return config_wrap.telegram_ui.buttons
 
@@ -1128,7 +1128,7 @@ def create_keyboard() -> List[List[str]]:
     return keyboard
 
 
-def bot_commands() -> Dict[str, str]:
+def bot_commands() -> dict[str, str]:
     commands = {
         "help": "list bot commands",
         "status": "send klipper status",
@@ -1191,7 +1191,7 @@ def prepare_command(marco: str) -> Optional[BotCommand]:
         return None
 
 
-def prepare_commands_list(macros: List[str], add_macros: bool) -> List[Any]:
+def prepare_commands_list(macros: list[str], add_macros: bool) -> list[Any]:
     commands = list(bot_commands().items())
     if add_macros:
         commands += list(filter(lambda el: el, map(prepare_command, macros)))  # type: ignore[arg-type]

--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -1,22 +1,27 @@
+from __future__ import annotations
+
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from io import BytesIO
 import logging
 import re
-from typing import Optional, Union
+from typing import TYPE_CHECKING
 
 import aiofiles
 import anyio
-from apscheduler.schedulers.base import BaseScheduler  # type: ignore[import-untyped]
 from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup, InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo, Message
 from telegram.constants import ChatAction, ParseMode
 from telegram.error import BadRequest
 
-from camera import Camera
-from configuration import ConfigWrapper
 from klippy import Klippy, PrintState
 from telegram_helper import TelegramMessageRepr
+
+if TYPE_CHECKING:
+    from apscheduler.schedulers.base import BaseScheduler  # type: ignore[import-untyped]
+
+    from camera import Camera
+    from configuration import ConfigWrapper
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +48,7 @@ class Notifier:
         self._percent: int = config.notifications.percent
         self._height: float = config.notifications.height
         self._interval: int = config.notifications.interval
-        self._notify_groups: list[tuple[int, Optional[int]]] = config.notifications.notify_groups
+        self._notify_groups: list[tuple[int, int | None]] = config.notifications.notify_groups
         self._group_only: bool = config.notifications.group_only
         self._max_upload_file_size: int = config.bot_config.max_upload_file_size
 
@@ -62,7 +67,7 @@ class Notifier:
         self._last_m117_status: str = ""
         self._last_tgnotify_status: str = ""
 
-        self._status_message: Optional[Message] = None
+        self._status_message: Message | None = None
         self._bzz_mess_id: int = 0
         self._groups_status_messages: dict[int, Message] = {}
 
@@ -130,7 +135,7 @@ class Notifier:
             self._interval = new_value
             self._reschedule_notifier_timer()
 
-    def get_status_keyboard(self, state: PrintState) -> Optional[InlineKeyboardMarkup]:
+    def get_status_keyboard(self, state: PrintState) -> InlineKeyboardMarkup | None:
         inline_keyboard = None
         if self._use_status_update_button and not state.is_finished:
             inline_keyboard = InlineKeyboardMarkup(
@@ -218,7 +223,7 @@ class Notifier:
                 await self.reset_notifications()
 
     # manual notification methods
-    def send_error(self, message: str, logs_upload: bool = False, preformat_text: Optional[str] = None) -> None:
+    def send_error(self, message: str, logs_upload: bool = False, preformat_text: str | None = None) -> None:
         if preformat_text:
             message += f"\n<pre>{preformat_text}</pre>"
         if logs_upload:
@@ -508,7 +513,7 @@ class Notifier:
 
     async def _send_image(self, paths: list[str], message: str) -> None:
         try:
-            photos_list: list[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]] = []
+            photos_list: list[InputMediaAudio | InputMediaDocument | InputMediaPhoto | InputMediaVideo] = []
             for path in paths:
                 path_obj = anyio.Path(path)
                 if not await path_obj.is_file():
@@ -552,7 +557,7 @@ class Notifier:
 
     async def _send_video(self, paths: list[str], message: str) -> None:
         try:
-            photos_list: list[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]] = []
+            photos_list: list[InputMediaAudio | InputMediaDocument | InputMediaPhoto | InputMediaVideo] = []
             for path in paths:
                 path_obj = anyio.Path(path)
                 if not await path_obj.is_file():
@@ -597,7 +602,7 @@ class Notifier:
 
     async def _send_document(self, paths: list[str], message: str) -> None:
         try:
-            photos_list: list[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]] = []
+            photos_list: list[InputMediaAudio | InputMediaDocument | InputMediaPhoto | InputMediaVideo] = []
             for path in paths:
                 path_obj = anyio.Path(path)
                 if not await path_obj.is_file():
@@ -664,7 +669,7 @@ class Notifier:
             await self._klippy.execute_gcode_script(f'RESPOND PREFIX="Notification params" MSG="Full Notification config: {full_conf}"')
 
     async def send_custom_inline_keyboard(self, message: str) -> None:
-        def parse_button(mess: str) -> Optional[InlineKeyboardButton]:
+        def parse_button(mess: str) -> InlineKeyboardButton | None:
             name = re.search(r"name\s*=\s*\'(.[^\']*)\'", mess)
             command = re.search(r"command\s*=\s*\'(.[^\']*)\'", mess)
             if name and command:

--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -675,9 +675,8 @@ class Notifier:
             if name and command:
                 gcode = "do_nothing" if command.group(1) == "delete" else f"gcode:{command.group(1)}"
                 return InlineKeyboardButton(name.group(1), callback_data=gcode)
-            else:
-                logger.warning("Bad command!")
-                return None
+            logger.warning("Bad command!")
+            return None
 
         keyboard: list[list[InlineKeyboardButton]] = list(  # noqa: C417
             map(

--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from io import BytesIO
 import logging
 import re
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import aiofiles
 import anyio
@@ -43,7 +43,7 @@ class Notifier:
         self._percent: int = config.notifications.percent
         self._height: float = config.notifications.height
         self._interval: int = config.notifications.interval
-        self._notify_groups: List[Tuple[int, Optional[int]]] = config.notifications.notify_groups
+        self._notify_groups: list[tuple[int, Optional[int]]] = config.notifications.notify_groups
         self._group_only: bool = config.notifications.group_only
         self._max_upload_file_size: int = config.bot_config.max_upload_file_size
 
@@ -54,7 +54,7 @@ class Notifier:
         self._pin_status_single_message: bool = config.telegram_ui.pin_status_single_message
         self._status_message_m117_update: bool = config.telegram_ui.status_message_m117_update
         self._use_status_update_button: bool = config.telegram_ui.status_update_button
-        self._message_parts: List[str] = config.status_message_content.content
+        self._message_parts: list[str] = config.status_message_content.content
 
         self._last_height: float = 0
         self._below_threshold: bool = False
@@ -64,7 +64,7 @@ class Notifier:
 
         self._status_message: Optional[Message] = None
         self._bzz_mess_id: int = 0
-        self._groups_status_messages: Dict[int, Message] = {}
+        self._groups_status_messages: dict[int, Message] = {}
 
         if logging_handler:
             logger.addHandler(logging_handler)
@@ -494,7 +494,7 @@ class Notifier:
         return message_match.group(1) if message_match else ""
 
     @staticmethod
-    def _parse_path(ws_message: str) -> List[str]:
+    def _parse_path(ws_message: str) -> list[str]:
         path_match = re.search(r"path\s*=\s*\'(.[^\']*)\'", ws_message)
         path_list_math = re.search(r"path\s*=\s*\[(?:\,*\s*\'(.[^\']*)\'\,*\s*)+\]", ws_message)
 
@@ -506,9 +506,9 @@ class Notifier:
             path = [""]
         return path
 
-    async def _send_image(self, paths: List[str], message: str) -> None:
+    async def _send_image(self, paths: list[str], message: str) -> None:
         try:
-            photos_list: List[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]] = []
+            photos_list: list[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]] = []
             for path in paths:
                 path_obj = anyio.Path(path)
                 if not await path_obj.is_file():
@@ -550,9 +550,9 @@ class Notifier:
             replace_existing=False,
         )
 
-    async def _send_video(self, paths: List[str], message: str) -> None:
+    async def _send_video(self, paths: list[str], message: str) -> None:
         try:
-            photos_list: List[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]] = []
+            photos_list: list[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]] = []
             for path in paths:
                 path_obj = anyio.Path(path)
                 if not await path_obj.is_file():
@@ -595,9 +595,9 @@ class Notifier:
             replace_existing=False,
         )
 
-    async def _send_document(self, paths: List[str], message: str) -> None:
+    async def _send_document(self, paths: list[str], message: str) -> None:
         try:
-            photos_list: List[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]] = []
+            photos_list: list[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]] = []
             for path in paths:
                 path_obj = anyio.Path(path)
                 if not await path_obj.is_file():
@@ -674,7 +674,7 @@ class Notifier:
                 logger.warning("Bad command!")
                 return None
 
-        keyboard: List[List[InlineKeyboardButton]] = list(  # noqa: C417
+        keyboard: list[list[InlineKeyboardButton]] = list(  # noqa: C417
             map(
                 lambda el: list(
                     filter(

--- a/bot/telegram_helper.py
+++ b/bot/telegram_helper.py
@@ -1,9 +1,13 @@
-from io import BytesIO
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from telegram import Bot, InlineKeyboardMarkup, InputMediaPhoto, Message
 from telegram.constants import ChatAction, ParseMode
 from telegram.helpers import escape_markdown
+
+if TYPE_CHECKING:
+    from io import BytesIO
 
 
 class TelegramMessageRepr:
@@ -11,7 +15,7 @@ class TelegramMessageRepr:
         self,
         text: str = "",
         parse_mode: str = ParseMode.HTML,
-        reply_markup: Optional[InlineKeyboardMarkup] = None,
+        reply_markup: InlineKeyboardMarkup | None = None,
         silent: bool = False,
         suppress_escaping: bool = False,
     ) -> None:
@@ -26,7 +30,7 @@ class TelegramMessageRepr:
     def is_silent(self) -> bool:
         return self._silent
 
-    async def send_as_reply(self, other_message: Message, photo: Optional[Union[BytesIO, bytes]] = None) -> None:
+    async def send_as_reply(self, other_message: Message, photo: BytesIO | bytes | None = None) -> None:
         if photo:
             await other_message.get_bot().send_chat_action(other_message.chat_id, action=ChatAction.UPLOAD_PHOTO)
             await other_message.reply_photo(
@@ -46,7 +50,7 @@ class TelegramMessageRepr:
                 reply_markup=self._reply_markup,
             )
 
-    async def send(self, bot: Bot, chat_id: int, photo: Optional[Union[BytesIO, bytes]] = None, message_thread_id: Optional[int] = None) -> Message:
+    async def send(self, bot: Bot, chat_id: int, photo: BytesIO | bytes | None = None, message_thread_id: int | None = None) -> Message:
         if photo:
             return await bot.send_photo(
                 chat_id,
@@ -67,7 +71,7 @@ class TelegramMessageRepr:
                 message_thread_id=message_thread_id,
             )
 
-    async def update_existing(self, other_message: Message, photo: Optional[Union[BytesIO, bytes]] = None) -> None:
+    async def update_existing(self, other_message: Message, photo: BytesIO | bytes | None = None) -> None:
         if photo:
             # Fixme: check if media in message!
             await other_message.edit_media(media=InputMediaPhoto(photo))

--- a/bot/telegram_helper.py
+++ b/bot/telegram_helper.py
@@ -61,15 +61,14 @@ class TelegramMessageRepr:
                 disable_notification=self._silent,
                 message_thread_id=message_thread_id,
             )
-        else:
-            return await bot.send_message(
-                chat_id,
-                text=self._text,
-                parse_mode=self._parse_mode,
-                reply_markup=self._reply_markup,
-                disable_notification=self._silent,
-                message_thread_id=message_thread_id,
-            )
+        return await bot.send_message(
+            chat_id,
+            text=self._text,
+            parse_mode=self._parse_mode,
+            reply_markup=self._reply_markup,
+            disable_notification=self._silent,
+            message_thread_id=message_thread_id,
+        )
 
     async def update_existing(self, other_message: Message, photo: BytesIO | bytes | None = None) -> None:
         if photo:

--- a/bot/timelapse.py
+++ b/bot/timelapse.py
@@ -1,17 +1,21 @@
+from __future__ import annotations
+
 import asyncio
 from concurrent.futures import Future, ThreadPoolExecutor
 import gc
 import logging
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
-from apscheduler.schedulers.base import BaseScheduler  # type: ignore[import-untyped]
-from telegram import Bot, Message
 from telegram.constants import ChatAction
 from telegram.error import BadRequest
 
-from camera import Camera
-from configuration import ConfigWrapper
-from klippy import Klippy
+if TYPE_CHECKING:
+    from apscheduler.schedulers.base import BaseScheduler  # type: ignore[import-untyped]
+    from telegram import Bot, Message
+
+    from camera import Camera
+    from configuration import ConfigWrapper
+    from klippy import Klippy
 
 logger = logging.getLogger(__name__)
 
@@ -239,7 +243,7 @@ class Timelapse:
                 replace_existing=True,
             )
 
-    async def upload_timelapse(self, lapse_filename: str, info_mess: Message, gcode_name_out: Optional[str] = None) -> None:
+    async def upload_timelapse(self, lapse_filename: str, info_mess: Message, gcode_name_out: str | None = None) -> None:
         try:
             (
                 video_bytes,

--- a/bot/timelapse.py
+++ b/bot/timelapse.py
@@ -193,16 +193,16 @@ class Timelapse:
         if not self._enabled:
             logger.debug("lapse is disabled")
             return
-        elif not self._klippy.printing_filename:
+        if not self._klippy.printing_filename:
             logger.debug("lapse is inactive for file undefined")
             return
-        elif not self._running:
+        if not self._running:
             logger.debug("lapse is not running at the moment")
             return
-        elif self._paused and not manually:
+        if self._paused and not manually:
             logger.debug("lapse is paused at the moment")
             return
-        elif not self._mode_manual and self._klippy.printing_duration <= 0.0:
+        if not self._mode_manual and self._klippy.printing_duration <= 0.0:
             logger.debug("lapse must not run with auto mode and zero print duration")
             return
 

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 from functools import wraps
 import logging
 import os
 import random
 import ssl
-from typing import Any, Callable, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 import aiofiles
 import anyio
@@ -11,15 +13,18 @@ import anyio
 os.environ.setdefault("WEBSOCKETS_MAX_LOG_SIZE", "1048576")
 os.environ.setdefault("WEBSOCKETS_BACKOFF_MAX_DELAY", "15.0")
 
-from apscheduler.schedulers.base import BaseScheduler  # type: ignore[import-untyped]
 import orjson
 from websockets.asyncio.client import ClientConnection, connect
 from websockets.protocol import State
 
-from configuration import ConfigWrapper
 from klippy import Klippy, PrintState
-from notifications import Notifier
-from timelapse import Timelapse
+
+if TYPE_CHECKING:
+    from apscheduler.schedulers.base import BaseScheduler  # type: ignore[import-untyped]
+
+    from configuration import ConfigWrapper
+    from notifications import Notifier
+    from timelapse import Timelapse
 
 JSONRPC_METHOD_NOT_FOUND = -32601
 
@@ -85,7 +90,7 @@ class WebSocketHelper:
     def _next_request_id(self) -> int:
         return random.randint(0, 300000)
 
-    async def _send_jsonrpc(self, method: str, params: Optional[dict[str, Any]] = None) -> None:
+    async def _send_jsonrpc(self, method: str, params: dict[str, Any] | None = None) -> None:
         request_id = self._next_request_id
         self._pending_requests[request_id] = method
         msg = {"jsonrpc": "2.0", "method": method, "id": request_id}

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -43,8 +43,7 @@ def websocket_alive(func: F) -> F:
         if self.websocket is None:
             logger.warning("Websocket call `%s` on non initialized ws", func.__name__)
             return None
-        else:
-            return func(self, *args, **kwargs)
+        return func(self, *args, **kwargs)
 
     return wrapper  # type: ignore[return-value]
 

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -3,7 +3,7 @@ import logging
 import os
 import random
 import ssl
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 
 import aiofiles
 import anyio
@@ -85,7 +85,7 @@ class WebSocketHelper:
     def _next_request_id(self) -> int:
         return random.randint(0, 300000)
 
-    async def _send_jsonrpc(self, method: str, params: Optional[Dict[str, Any]] = None) -> None:
+    async def _send_jsonrpc(self, method: str, params: Optional[dict[str, Any]] = None) -> None:
         request_id = self._next_request_id
         self._pending_requests[request_id] = method
         msg = {"jsonrpc": "2.0", "method": method, "id": request_id}
@@ -121,7 +121,7 @@ class WebSocketHelper:
         await self._notifier.stop_all()
         self._timelapse.stop_all()
 
-    async def status_response(self, status_resp: Dict[str, Any]) -> None:
+    async def status_response(self, status_resp: dict[str, Any]) -> None:
         if "print_stats" in status_resp:
             print_stats = status_resp["print_stats"]
             if print_stats["state"] in ["printing", "paused"]:
@@ -152,7 +152,7 @@ class WebSocketHelper:
 
         self.parse_sensors(status_resp)
 
-    async def notify_gcode_response(self, message_params: List[str]) -> None:
+    async def notify_gcode_response(self, message_params: list[str]) -> None:
         if self._timelapse.manual_mode:
             if "timelapse start" in message_params:
                 if not self._klippy.printing_filename:
@@ -199,7 +199,7 @@ class WebSocketHelper:
         if message_params_loc.startswith("tg_send_document"):
             self._notifier.send_document(message_params_loc)
 
-    async def notify_status_update(self, message_params: List[Dict[str, Any]]) -> None:
+    async def notify_status_update(self, message_params: list[dict[str, Any]]) -> None:
         message_params_loc = message_params[0]
         if "display_status" in message_params_loc:
             if "message" in message_params_loc["display_status"]:
@@ -224,7 +224,7 @@ class WebSocketHelper:
 
         self.parse_sensors(message_params_loc)
 
-    def parse_sensors(self, message_parts_loc: Dict[str, Any]) -> None:
+    def parse_sensors(self, message_parts_loc: dict[str, Any]) -> None:
         for sens in [key for key in message_parts_loc if key.startswith("temperature_sensor")]:
             self._klippy.update_sensor(sens.replace("temperature_sensor ", ""), message_parts_loc[sens])
 
@@ -240,7 +240,7 @@ class WebSocketHelper:
                 message_parts_loc[heater],
             )
 
-    async def parse_print_stats(self, message_params: List[Dict[str, Any]]) -> None:
+    async def parse_print_stats(self, message_params: list[dict[str, Any]]) -> None:
         state = ""
         print_stats_loc = message_params[0]["print_stats"]
         # Fixme:  maybe do not parse without state? history data may not be available
@@ -311,7 +311,7 @@ class WebSocketHelper:
         elif state:
             logger.error("Unknown state: %s", state)
 
-    def power_device_state(self, device: Dict[str, Any]) -> None:
+    def power_device_state(self, device: dict[str, Any]) -> None:
         device_name = device["device"]
         device_state = bool(device["status"] == "on")
         self._klippy.update_power_device(device_name, device)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,13 +75,16 @@ select = [
     "G",     # flake8-logging-format
     "I",     # isort
     "ICN",   # flake8-import-conventions
+    "ISC",   # flake8-implicit-str-concat
     "LOG",   # flake8-logging
     "PERF",  # perflint
     "PIE",   # flake8-pie
+    "PT",    # flake8-pytest-style
     "PLC",   # pylint convention
     "PLE",   # pylint error
     "PLW",   # pylint warning
     "PTH",   # flake8-use-pathlib
+    "RSE",   # flake8-raise
     "RUF",   # ruff-specific
     "SIM",   # flake8-simplify
     "SLF",   # flake8-self
@@ -113,7 +116,7 @@ known-first-party = [
     "telegram_helper",
 ]
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = [ "SLF001" ]
+"tests/**/*.py" = [ "S101", "S105", "SLF001" ]
 
 [tool.codespell]
 skip = "uv.lock"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ select = [
     "C4",    # flake8-comprehensions
     "E",     # pycodestyle errors
     "F",     # pyflakes
+    "FA",    # flake8-future-annotations
     "FLY",   # flynt
     "FURB",  # refurb
     "G",     # flake8-logging-format
@@ -88,6 +89,7 @@ select = [
     "TCH",   # flake8-type-checking
     "TID",   # flake8-tidy-imports
     "TRY",   # tryceratops
+    "UP",    # pyupgrade
     "W",     # pycodestyle warnings
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ line-length = 200
 [tool.ruff.lint]
 select = [
     "A",     # flake8-builtins
+    "ARG",   # flake8-unused-arguments
     "ASYNC", # flake8-async
     "B",     # flake8-bugbear
     "C4",    # flake8-comprehensions
@@ -77,6 +78,7 @@ select = [
     "ICN",   # flake8-import-conventions
     "ISC",   # flake8-implicit-str-concat
     "LOG",   # flake8-logging
+    "N",     # pep8-naming
     "PERF",  # perflint
     "PIE",   # flake8-pie
     "PT",    # flake8-pytest-style
@@ -84,6 +86,7 @@ select = [
     "PLE",   # pylint error
     "PLW",   # pylint warning
     "PTH",   # flake8-use-pathlib
+    "RET",   # flake8-return
     "RSE",   # flake8-raise
     "RUF",   # ruff-specific
     "SIM",   # flake8-simplify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,9 +130,15 @@ table_format = "long"
 [tool.mypy]
 python_version = "3.9"
 no_namespace_packages = true
-exclude = "tests"
 strict = true
 enable_error_code = [ "ignore-without-code" ]
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+disallow_untyped_calls = false
+[[tool.mypy.overrides]]
+module = "_pytest.*"
+follow_imports = "skip"
 
 [tool.pytest.ini_options]
 python_files = "*_test.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,8 +134,8 @@ strict = true
 enable_error_code = [ "ignore-without-code" ]
 [[tool.mypy.overrides]]
 module = "tests.*"
-disallow_untyped_defs = false
-disallow_untyped_calls = false
+disallow_untyped_decorators = false
+disable_error_code = [ "method-assign" ]
 [[tool.mypy.overrides]]
 module = "_pytest.*"
 follow_imports = "skip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ table_format = "long"
 
 [tool.mypy]
 python_version = "3.9"
-no_namespace_packages = true
+mypy_path = "bot"
 strict = true
 enable_error_code = [ "ignore-without-code" ]
 [[tool.mypy.overrides]]
@@ -143,3 +143,4 @@ follow_imports = "skip"
 [tool.pytest.ini_options]
 python_files = "*_test.py"
 testpaths = [ "tests" ]
+pythonpath = [ "bot" ]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,0 @@
-from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parent.parent / "bot"))

--- a/tests/camera_test.py
+++ b/tests/camera_test.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -33,7 +34,7 @@ def make_camera(test_dir: Path) -> Camera:
     klippy.printing = True
     klippy.printing_duration = 100.0
 
-    return Camera(config, klippy, None)
+    return Camera(config, klippy, logging.NullHandler())
 
 
 LAPSES_NAMES = ["lapse1", "lapse2", "lapse3", "lapse4"]

--- a/tests/camera_test.py
+++ b/tests/camera_test.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from bot.camera import Camera
+from camera import Camera
 
 
 def make_camera(test_dir: Path) -> Camera:

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -3,7 +3,7 @@ import pathlib
 
 import pytest
 
-from bot.configuration import ConfigWrapper  # type: ignore
+from bot.configuration import ConfigWrapper  # type: ignore[import-not-found]
 
 CONFIG_PATH = "tests/resources/telegram.conf"
 CONFIG_MINIMAL_PATH = "tests/resources/telegram_minimal.conf"
@@ -60,7 +60,7 @@ def config_with_auth(tmp_path):
     return wrapper
 
 
-def _read_dumped_config(wrapper) -> configparser.ConfigParser:
+def _read_dumped_config(wrapper: ConfigWrapper) -> configparser.ConfigParser:
     """Dump config to log and parse the written INI back."""
     wrapper.dump_config_to_log()
     with wrapper.bot_config.log_file.open(encoding="utf-8") as f:

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -3,7 +3,7 @@ import pathlib
 
 import pytest
 
-from bot.configuration import ConfigWrapper  # type: ignore[import-not-found]
+from configuration import ConfigWrapper
 
 CONFIG_PATH = "tests/resources/telegram.conf"
 CONFIG_MINIMAL_PATH = "tests/resources/telegram_minimal.conf"

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -1,5 +1,6 @@
 import configparser
 import pathlib
+from pathlib import Path
 
 import pytest
 
@@ -12,48 +13,48 @@ CONFIG_WITH_SECRETS_PATH = "tests/resources/telegram_secrets.conf"
 CONFIG_WITH_AUTH_PATH = "tests/resources/telegram_with_auth.conf"
 
 
-def test_template_config_has_no_errors():
+def test_template_config_has_no_errors() -> None:
     config_path = pathlib.Path(CONFIG_TEMPLATE_PATH).absolute().as_posix()
     assert ConfigWrapper(config_path).configuration_errors == ""
 
 
-def test_minimal_config_has_no_errors():
+def test_minimal_config_has_no_errors() -> None:
     config_path = pathlib.Path(CONFIG_MINIMAL_PATH).absolute().as_posix()
     assert ConfigWrapper(config_path).configuration_errors == ""
 
 
 @pytest.fixture
-def config_secrets_helper():
+def config_secrets_helper() -> ConfigWrapper:
     config_path = pathlib.Path(CONFIG_WITH_SECRETS_PATH).absolute().as_posix()
     return ConfigWrapper(config_path)
 
 
-def test_config_with_secrets_has_no_errors(config_secrets_helper):
+def test_config_with_secrets_has_no_errors(config_secrets_helper: ConfigWrapper) -> None:
     assert config_secrets_helper.configuration_errors == ""
 
 
-def test_config_with_secrets_is_valid(config_secrets_helper):
+def test_config_with_secrets_is_valid(config_secrets_helper: ConfigWrapper) -> None:
     assert config_secrets_helper.secrets.chat_id == 1661233333
     assert config_secrets_helper.secrets.token == "23423423334:sdfgsdfg-doroasd"
 
 
 @pytest.fixture
-def config_helper():
+def config_helper() -> ConfigWrapper:
     config_path = pathlib.Path(CONFIG_PATH).absolute().as_posix()
     return ConfigWrapper(config_path)
 
 
-def test_config_has_no_errors(config_helper):
+def test_config_has_no_errors(config_helper: ConfigWrapper) -> None:
     assert config_helper.configuration_errors == ""
 
 
-def test_config_bot_is_valid(config_helper):
+def test_config_bot_is_valid(config_helper: ConfigWrapper) -> None:
     assert config_helper.secrets.chat_id == 16612341234
     assert config_helper.secrets.token == "23423423334:sdfgsdfg-dfgdfgsdfg"
 
 
 @pytest.fixture
-def config_with_auth(tmp_path):
+def config_with_auth(tmp_path: Path) -> ConfigWrapper:
     config_path = pathlib.Path(CONFIG_WITH_AUTH_PATH).absolute().as_posix()
     wrapper = ConfigWrapper(config_path)
     wrapper.bot_config.log_file = tmp_path / "bot.log"
@@ -70,33 +71,33 @@ def _read_dumped_config(wrapper: ConfigWrapper) -> configparser.ConfigParser:
     return dumped
 
 
-def test_dump_redacts_bot_token(config_with_auth):
+def test_dump_redacts_bot_token(config_with_auth: ConfigWrapper) -> None:
     dumped = _read_dumped_config(config_with_auth)
     assert dumped.get("bot", "bot_token") == "<redacted>"
 
 
-def test_dump_redacts_chat_id(config_with_auth):
+def test_dump_redacts_chat_id(config_with_auth: ConfigWrapper) -> None:
     dumped = _read_dumped_config(config_with_auth)
     assert dumped.get("bot", "chat_id") == "<redacted>"
 
 
-def test_dump_redacts_password(config_with_auth):
+def test_dump_redacts_password(config_with_auth: ConfigWrapper) -> None:
     dumped = _read_dumped_config(config_with_auth)
     assert dumped.get("bot", "password") == "<redacted>"
 
 
-def test_dump_redacts_api_token(config_with_auth):
+def test_dump_redacts_api_token(config_with_auth: ConfigWrapper) -> None:
     dumped = _read_dumped_config(config_with_auth)
     assert dumped.get("bot", "api_token") == "<redacted>"
 
 
-def test_dump_does_not_mutate_live_config(config_with_auth):
+def test_dump_does_not_mutate_live_config(config_with_auth: ConfigWrapper) -> None:
     original_token = config_with_auth._config.get("bot", "bot_token")
     config_with_auth.dump_config_to_log()
     assert config_with_auth._config.get("bot", "bot_token") == original_token
 
 
-def test_dump_does_not_add_redacted_for_unset_options(config_helper, tmp_path):
+def test_dump_does_not_add_redacted_for_unset_options(config_helper: ConfigWrapper, tmp_path: Path) -> None:
     """Options not present in config should not appear as <redacted>."""
     config_helper.bot_config.log_file = tmp_path / "bot.log"
     dumped = _read_dumped_config(config_helper)

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -33,7 +33,8 @@ def test_config_with_secrets_has_no_errors(config_secrets_helper):
 
 
 def test_config_with_secrets_is_valid(config_secrets_helper):
-    assert config_secrets_helper.secrets.chat_id == 1661233333 and config_secrets_helper.secrets.token == "23423423334:sdfgsdfg-doroasd"
+    assert config_secrets_helper.secrets.chat_id == 1661233333
+    assert config_secrets_helper.secrets.token == "23423423334:sdfgsdfg-doroasd"
 
 
 @pytest.fixture
@@ -47,7 +48,8 @@ def test_config_has_no_errors(config_helper):
 
 
 def test_config_bot_is_valid(config_helper):
-    assert config_helper.secrets.chat_id == 16612341234 and config_helper.secrets.token == "23423423334:sdfgsdfg-dfgdfgsdfg"
+    assert config_helper.secrets.chat_id == 16612341234
+    assert config_helper.secrets.token == "23423423334:sdfgsdfg-dfgdfgsdfg"
 
 
 @pytest.fixture

--- a/tests/klippy_test.py
+++ b/tests/klippy_test.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -14,7 +15,7 @@ test_sensors = {
 }
 
 
-def test_sensor_message():
+def test_sensor_message() -> None:
     heater_message = Klippy._sensor_message("heater", test_sensors["heater"])
     temp_sensor_message = Klippy._sensor_message("temp", test_sensors["temp"])
     fan_message = Klippy._sensor_message("fan", test_sensors["fan"])
@@ -24,7 +25,7 @@ def test_sensor_message():
 
 
 @pytest.fixture
-def mock_klippy():
+def mock_klippy() -> Klippy:
     config = MagicMock()
     config.bot_config.ssl = False
     config.bot_config.host = "localhost"
@@ -47,18 +48,18 @@ def mock_klippy():
 
 
 @pytest.mark.asyncio
-async def test_jwt_refresh_updates_headers_on_retry(mock_klippy):
+async def test_jwt_refresh_updates_headers_on_retry(mock_klippy: Klippy) -> None:
     mock_klippy._jwt_token = "expired_token"
     mock_klippy._refresh_token = "valid_refresh"
 
     retry_headers = {}
 
-    async def fake_refresh():
+    async def fake_refresh() -> None:
         mock_klippy._jwt_token = "new_token"
 
     call_count = 0
 
-    async def fake_request(method, url, **kwargs):
+    async def fake_request(method: str, url: str, **kwargs: Any) -> httpx.Response:
         nonlocal call_count
         call_count += 1
         if call_count == 1:
@@ -75,7 +76,7 @@ async def test_jwt_refresh_updates_headers_on_retry(mock_klippy):
 
 
 @pytest.mark.asyncio
-async def test_set_printing_filename_handles_bad_response(mock_klippy):
+async def test_set_printing_filename_handles_bad_response(mock_klippy: Klippy) -> None:
     error_response = httpx.Response(
         status_code=404,
         text='{"error": {"message": "File not found"}}',
@@ -87,7 +88,7 @@ async def test_set_printing_filename_handles_bad_response(mock_klippy):
     assert mock_klippy.printing_filename == "nonexistent_file.gcode"
 
 
-def test_progress_shows_current_and_object_height(mock_klippy):
+def test_progress_shows_current_and_object_height(mock_klippy: Klippy) -> None:
     mock_klippy._message_parts = ["progress", "height"]
     mock_klippy._printing_filename = "test.gcode"
     mock_klippy.printing_height = 5.2
@@ -96,7 +97,7 @@ def test_progress_shows_current_and_object_height(mock_klippy):
     assert "height: 5.2 / 19.6mm" in msg
 
 
-def test_start_shows_only_object_height(mock_klippy):
+def test_start_shows_only_object_height(mock_klippy: Klippy) -> None:
     mock_klippy._message_parts = ["progress", "height"]
     mock_klippy._printing_filename = "test.gcode"
     mock_klippy.printing_height = 15.3
@@ -106,7 +107,7 @@ def test_start_shows_only_object_height(mock_klippy):
     assert "15.3" not in msg
 
 
-def test_finish_shows_only_object_height(mock_klippy):
+def test_finish_shows_only_object_height(mock_klippy: Klippy) -> None:
     mock_klippy._message_parts = ["progress", "height"]
     mock_klippy._printing_filename = "test.gcode"
     mock_klippy.printing_height = 2.0
@@ -116,7 +117,7 @@ def test_finish_shows_only_object_height(mock_klippy):
     assert "2.0" not in msg
 
 
-def test_height_fallback_without_object_height(mock_klippy):
+def test_height_fallback_without_object_height(mock_klippy: Klippy) -> None:
     mock_klippy._message_parts = ["progress", "height"]
     mock_klippy._printing_filename = "test.gcode"
     mock_klippy.printing_height = 5.2
@@ -125,7 +126,7 @@ def test_height_fallback_without_object_height(mock_klippy):
     assert "height: 5.2mm" in msg
 
 
-def test_no_height_when_both_zero(mock_klippy):
+def test_no_height_when_both_zero(mock_klippy: Klippy) -> None:
     mock_klippy._message_parts = ["progress", "height"]
     mock_klippy._printing_filename = "test.gcode"
     mock_klippy.printing_height = 0.0
@@ -134,7 +135,7 @@ def test_no_height_when_both_zero(mock_klippy):
     assert "height" not in msg
 
 
-def test_start_shows_only_total_filament(mock_klippy):
+def test_start_shows_only_total_filament(mock_klippy: Klippy) -> None:
     mock_klippy._message_parts = ["progress", "filament_length", "filament_weight"]
     mock_klippy._printing_filename = "test.gcode"
     mock_klippy.filament_total = 5000.0
@@ -147,7 +148,7 @@ def test_start_shows_only_total_filament(mock_klippy):
     assert "/" not in msg.split("Filament:")[1]
 
 
-def test_finish_shows_only_used_filament(mock_klippy):
+def test_finish_shows_only_used_filament(mock_klippy: Klippy) -> None:
     mock_klippy._message_parts = ["progress", "filament_length", "filament_weight"]
     mock_klippy._printing_filename = "test.gcode"
     mock_klippy.filament_total = 5000.0
@@ -159,7 +160,7 @@ def test_finish_shows_only_used_filament(mock_klippy):
     assert "/" not in msg.split("Filament")[1]
 
 
-def test_finish_shows_printed_for(mock_klippy):
+def test_finish_shows_printed_for(mock_klippy: Klippy) -> None:
     mock_klippy._message_parts = ["progress", "print_duration"]
     mock_klippy._printing_filename = "test.gcode"
     mock_klippy.printing_duration = 1800.0
@@ -168,7 +169,7 @@ def test_finish_shows_printed_for(mock_klippy):
     assert "Printing for" not in msg
 
 
-def test_finish_hides_eta(mock_klippy):
+def test_finish_hides_eta(mock_klippy: Klippy) -> None:
     mock_klippy._message_parts = ["progress", "eta", "finish_time"]
     mock_klippy._printing_filename = "test.gcode"
     mock_klippy.file_estimated_time = 3600.0
@@ -178,7 +179,7 @@ def test_finish_hides_eta(mock_klippy):
     assert "Finish at" not in msg
 
 
-def test_start_hides_duration(mock_klippy):
+def test_start_hides_duration(mock_klippy: Klippy) -> None:
     mock_klippy._message_parts = ["progress", "print_duration"]
     mock_klippy._printing_filename = "test.gcode"
     mock_klippy.printing_duration = 1800.0
@@ -186,7 +187,7 @@ def test_start_hides_duration(mock_klippy):
     assert "Printing for" not in msg
 
 
-def test_title_bold(mock_klippy):
+def test_title_bold(mock_klippy: Klippy) -> None:
     mock_klippy._message_parts = ["progress"]
     mock_klippy._printing_filename = "test.gcode"
     msg = mock_klippy._get_printing_file_info()
@@ -194,7 +195,7 @@ def test_title_bold(mock_klippy):
     assert "</b>" in msg
 
 
-def test_progress_no_trailing_zero(mock_klippy):
+def test_progress_no_trailing_zero(mock_klippy: Klippy) -> None:
     mock_klippy._message_parts = ["progress"]
     mock_klippy._printing_filename = "test.gcode"
     mock_klippy.printing_progress = 0.8
@@ -204,7 +205,7 @@ def test_progress_no_trailing_zero(mock_klippy):
 
 
 @pytest.mark.asyncio
-async def test_switch_device_sync_delegates_to_async(mock_klippy):
+async def test_switch_device_sync_delegates_to_async(mock_klippy: Klippy) -> None:
     mock_klippy._loop = asyncio.get_running_loop()
     ok_response = httpx.Response(status_code=200, text='{"result":"ok"}', request=httpx.Request("POST", "http://localhost:7125/machine/device_power/device"))
     mock_klippy.make_request = AsyncMock(return_value=ok_response)
@@ -220,7 +221,7 @@ async def test_switch_device_sync_delegates_to_async(mock_klippy):
 
 
 @pytest.mark.asyncio
-async def test_execute_gcode_script_sync_delegates_to_async(mock_klippy):
+async def test_execute_gcode_script_sync_delegates_to_async(mock_klippy: Klippy) -> None:
     mock_klippy._loop = asyncio.get_running_loop()
     ok_response = httpx.Response(status_code=200, text='{"result":"ok"}', request=httpx.Request("GET", "http://localhost:7125/printer/gcode/script"))
     mock_klippy.make_request = AsyncMock(return_value=ok_response)
@@ -232,7 +233,7 @@ async def test_execute_gcode_script_sync_delegates_to_async(mock_klippy):
 
 
 @pytest.mark.asyncio
-async def test_switch_device_sync_reports_error(mock_klippy):
+async def test_switch_device_sync_reports_error(mock_klippy: Klippy) -> None:
     mock_klippy._loop = asyncio.get_running_loop()
     err_response = httpx.Response(
         status_code=400,

--- a/tests/klippy_test.py
+++ b/tests/klippy_test.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -42,7 +43,7 @@ def mock_klippy():
     config.secrets.passwd = ""
     config.secrets.api_token = ""
 
-    return Klippy(config, None)
+    return Klippy(config, logging.NullHandler())
 
 
 @pytest.mark.asyncio

--- a/tests/klippy_test.py
+++ b/tests/klippy_test.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
-from bot.klippy import Klippy, PowerDevice, PrintState  # type: ignore
+from bot.klippy import Klippy, PowerDevice, PrintState  # type: ignore[import-not-found]
 
 test_sensors = {
     "heater": {"temperature": 155.345325234, "target": 255.343434, "power": 0.60},

--- a/tests/klippy_test.py
+++ b/tests/klippy_test.py
@@ -17,7 +17,9 @@ def test_sensor_message():
     heater_message = Klippy._sensor_message("heater", test_sensors["heater"])
     temp_sensor_message = Klippy._sensor_message("temp", test_sensors["temp"])
     fan_message = Klippy._sensor_message("fan", test_sensors["fan"])
-    assert heater_message == "♨️ Heater: 155 °C ➡️ 255 °C 🔥" and fan_message == "🌪️ Fan: 155 °C ➡️ 255 °C 75% 2550 RPM" and temp_sensor_message == "🌡️ Temp: 155 °C"
+    assert heater_message == "♨️ Heater: 155 °C ➡️ 255 °C 🔥"
+    assert fan_message == "🌪️ Fan: 155 °C ➡️ 255 °C 75% 2550 RPM"
+    assert temp_sensor_message == "🌡️ Temp: 155 °C"
 
 
 @pytest.fixture
@@ -187,7 +189,8 @@ def test_title_bold(mock_klippy):
     mock_klippy._message_parts = ["progress"]
     mock_klippy._printing_filename = "test.gcode"
     msg = mock_klippy._get_printing_file_info()
-    assert "<b>" in msg and "</b>" in msg
+    assert "<b>" in msg
+    assert "</b>" in msg
 
 
 def test_progress_no_trailing_zero(mock_klippy):

--- a/tests/klippy_test.py
+++ b/tests/klippy_test.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
-from bot.klippy import Klippy, PowerDevice, PrintState  # type: ignore[import-not-found]
+from klippy import Klippy, PowerDevice, PrintState
 
 test_sensors = {
     "heater": {"temperature": 155.345325234, "target": 255.343434, "power": 0.60},

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,7 +1,7 @@
 from main import prepare_command
 
 
-def test_bot_commands_preparation():
+def test_bot_commands_preparation() -> None:
     valid_command = prepare_command("SuperCommand")
     long_command = prepare_command("InvalidCommandToooooooooooooooooLong")
     invalid_symblos_command = prepare_command("InvalidSymblosCommand&^)))")

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,4 +1,4 @@
-from bot.main import prepare_command  # type: ignore
+from bot.main import prepare_command  # type: ignore[import-not-found]
 
 
 def test_bot_commands_preparation():

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -5,4 +5,6 @@ def test_bot_commands_preparation():
     valid_command = prepare_command("SuperCommand")
     long_command = prepare_command("InvalidCommandToooooooooooooooooLong")
     invalid_symblos_command = prepare_command("InvalidSymblosCommand&^)))")
-    assert valid_command and long_command is None and invalid_symblos_command is None
+    assert valid_command
+    assert long_command is None
+    assert invalid_symblos_command is None

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,4 +1,4 @@
-from bot.main import prepare_command  # type: ignore[import-not-found]
+from main import prepare_command
 
 
 def test_bot_commands_preparation():

--- a/tests/notifications_test.py
+++ b/tests/notifications_test.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 from notifications import Notifier
 
 
-def make_notifier(height=5.0, percent=0):
+def make_notifier(height: float = 5.0, percent: int = 0) -> Notifier:
     config = MagicMock()
     config.secrets.chat_id = 123
     config.notifications.enabled = True
@@ -31,7 +31,7 @@ def make_notifier(height=5.0, percent=0):
     return Notifier(config, MagicMock(), klippy, MagicMock(), MagicMock(), logging.NullHandler())
 
 
-def test_height_notification_triggers_at_threshold():
+def test_height_notification_triggers_at_threshold() -> None:
     n = make_notifier(height=2.5)
     n._schedule_notification = MagicMock()
 
@@ -57,7 +57,7 @@ def test_height_notification_triggers_at_threshold():
     assert n._schedule_notification.call_count == 3
 
 
-def test_height_notification_with_real_layers():
+def test_height_notification_with_real_layers() -> None:
     """With 0.2mm layers Z never lands exactly on 2.5 — must still trigger."""
     n = make_notifier(height=2.5)
     n._schedule_notification = MagicMock()
@@ -86,7 +86,7 @@ def test_height_notification_with_real_layers():
     assert n._schedule_notification.call_count == 2
 
 
-def test_height_notification_rejects_wild_z_jumps():
+def test_height_notification_rejects_wild_z_jumps() -> None:
     """Z far above threshold (start gcode, travel moves) should not fire."""
     n = make_notifier(height=2.5)
     n._schedule_notification = MagicMock()
@@ -112,7 +112,7 @@ def test_height_notification_rejects_wild_z_jumps():
     assert n._schedule_notification.call_count == 2
 
 
-def test_height_notification_sequential_objects():
+def test_height_notification_sequential_objects() -> None:
     """Z drops back to first layer between objects — should restart notifications."""
     n = make_notifier(height=2.5)
     n._schedule_notification = MagicMock()
@@ -142,7 +142,7 @@ def test_height_notification_sequential_objects():
     assert n._schedule_notification.call_count == 5
 
 
-def test_height_notification_guards():
+def test_height_notification_guards() -> None:
     n = make_notifier(height=5)
     n._schedule_notification = MagicMock()
 

--- a/tests/notifications_test.py
+++ b/tests/notifications_test.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 
-from bot.notifications import Notifier  # type: ignore[import-not-found]
+from notifications import Notifier
 
 
 def make_notifier(height=5.0, percent=0):

--- a/tests/notifications_test.py
+++ b/tests/notifications_test.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 
-from bot.notifications import Notifier  # type: ignore
+from bot.notifications import Notifier  # type: ignore[import-not-found]
 
 
 def make_notifier(height=5.0, percent=0):

--- a/tests/notifications_test.py
+++ b/tests/notifications_test.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import MagicMock
 
 from notifications import Notifier
@@ -27,7 +28,7 @@ def make_notifier(height=5.0, percent=0):
     klippy.printing = True
     klippy.printing_duration = 100.0
 
-    return Notifier(config, MagicMock(), klippy, MagicMock(), MagicMock(), None)
+    return Notifier(config, MagicMock(), klippy, MagicMock(), MagicMock(), logging.NullHandler())
 
 
 def test_height_notification_triggers_at_threshold():


### PR DESCRIPTION
- Python 3.9 actually already supports modern type hints.
- Enable few more ruff rules.
- One of them is fixing compound conditions in `assert`, this gives better error message when they fail
- Enable basic mypy checks for tests, they were not tested before.
- Also fix how imports for bot code work in tests, now they are able to be checked by mypy.
- This found issue that `None` was passed instead of `logging_handler`, fixed that.
- Add missing type hints in tests.