### PR TITLE
Bug fixes, cleanup, and additional ruff rules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
 
   docker:
     needs: lint-test
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.repository == 'nlef/moonraker-telegram-bot'
     runs-on: ubuntu-24.04
     steps:
       -

--- a/bot/assets/ffmpegcv_custom.py
+++ b/bot/assets/ffmpegcv_custom.py
@@ -40,7 +40,12 @@ class FFmpegReaderStreamRTCustom(FFmpegReader):  # type: ignore[misc]
         vid.pix_fmt = pix_fmt
 
         (vid.crop_width, vid.crop_height), (vid.width, vid.height), filteropt = get_videofilter_cpu(
-            (vid.origin_width, vid.origin_height), pix_fmt, crop_xywh, resize, resize_keepratio, resize_keepratioalign
+            (vid.origin_width, vid.origin_height),
+            pix_fmt,
+            crop_xywh,
+            resize,
+            resize_keepratio,
+            resize_keepratioalign,
         )
         vid.size = (vid.width, vid.height)
 

--- a/bot/camera.py
+++ b/bot/camera.py
@@ -90,7 +90,7 @@ def os_nice(value: int) -> None:
 class Camera:
     """Base camera backend."""
 
-    def __init__(self, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler):
+    def __init__(self, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> None:
         self.enabled: bool = bool(config.camera.enabled and config.camera.host)
         self._host = int(config.camera.host) if str.isdigit(config.camera.host) else config.camera.host
         self._threads: int = config.camera.threads
@@ -625,7 +625,7 @@ class Camera:
 class FFmpegCamera(Camera):
     """Camera backend using FFmpeg for RTSP/stream capture."""
 
-    def __init__(self, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler):
+    def __init__(self, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> None:
         super().__init__(config, klippy, logging_handler)
 
         self._cam_timeout: int = 5
@@ -639,7 +639,7 @@ class FFmpegCamera(Camera):
 class MjpegCamera(Camera):
     """Camera backend using MJPEG snapshot/stream URLs."""
 
-    def __init__(self, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler):
+    def __init__(self, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> None:
         super().__init__(config, klippy, logging_handler)
         self._img_extension = "jpeg"
         self._raw_frame_extension: str = "jpeg"
@@ -792,7 +792,7 @@ class MjpegCamera(Camera):
 class RawStreamCamera(MjpegCamera):
     """Camera backend for direct H.264/snapshot passthrough without re-encoding."""
 
-    def __init__(self, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler):
+    def __init__(self, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> None:
         super().__init__(config, klippy, logging_handler)
 
         if self._flip_vertically or self._flip_horizontally or self._rotate_code > -10:

--- a/bot/camera.py
+++ b/bot/camera.py
@@ -497,7 +497,7 @@ class Camera:
 
     def _create_timelapse(self, printing_filename: str, gcode_name: str, info_mess: Message, loop: asyncio.AbstractEventLoop) -> tuple[bytes, bytes, int, int, str, str]:
         if not printing_filename:
-            raise ValueError("Gcode file name is empty")  # noqa: TRY003
+            raise ValueError("Gcode file name is empty")
 
         while self.light_need_off:
             time.sleep(1)
@@ -509,7 +509,7 @@ class Camera:
         raw_frames = list(lapse_dir.glob(f"*.{self._raw_frame_extension}"))
         photo_count = len(raw_frames)
         if photo_count == 0:
-            raise ValueError(f"Empty photos list for {printing_filename} in lapse path {lapse_dir}")  # noqa: TRY003
+            raise ValueError(f"Empty photos list for {printing_filename} in lapse path {lapse_dir}")
 
         lock_file = lapse_dir / "lapse.lock"
         if not lock_file.is_file():

--- a/bot/camera.py
+++ b/bot/camera.py
@@ -15,7 +15,7 @@ import pickle
 import subprocess
 import threading
 import time
-from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, TypeVar, cast
 
 from assets.ffmpegcv_custom import FFmpegReaderStreamRTCustomInit
 import ffmpegcv  # type: ignore[import-untyped]
@@ -136,15 +136,15 @@ class Camera:
         self._light_requests: int = 0
         self._light_request_lock: threading.Lock = threading.Lock()
 
-        self._rotate_code: int
+        self._rotation_count: int | None
         if config.camera.rotate == "90_cw":
-            self._rotate_code = 1
-        elif config.camera.rotate == "90_ccw":
-            self._rotate_code = 3
+            self._rotation_count = 1
         elif config.camera.rotate == "180":
-            self._rotate_code = 2
+            self._rotation_count = 2
+        elif config.camera.rotate == "90_ccw":
+            self._rotation_count = 3
         else:
-            self._rotate_code = -10
+            self._rotation_count = None
 
         self._lapse_missed_frames: int = 0
 
@@ -322,8 +322,8 @@ class Camera:
                     image = np.flipud(image)
                 if self._flip_horizontally:
                     image = np.fliplr(image)
-                if self._rotate_code > -10:
-                    image = np.rot90(image, k=self._rotate_code, axes=(1, 0))
+                if self._rotation_count is not None:
+                    image = np.rot90(image, k=self._rotation_count, axes=(1, 0))
 
             ndaarr = image[:, :, [2, 1, 0]].copy() if rgb else image.copy()  # type: ignore[index, union-attr]
             image = None
@@ -365,8 +365,8 @@ class Camera:
                 frame_local = np.flipud(frame_local)
             if self._flip_horizontally:
                 frame_local = np.fliplr(frame_local)
-            if self._rotate_code > -10:
-                frame_local = np.rot90(frame_local, k=self._rotate_code, axes=(1, 0))
+            if self._rotation_count is not None:
+                frame_local = np.rot90(frame_local, k=self._rotation_count, axes=(1, 0))
             return frame_local
 
         with self._camera_lock:
@@ -639,6 +639,12 @@ class FFmpegCamera(Camera):
 class MjpegCamera(Camera):
     """Camera backend using MJPEG snapshot/stream URLs."""
 
+    _ROTATION_TO_TRANSPOSE: ClassVar[dict[int, Image.Transpose]] = {
+        1: Image.Transpose.ROTATE_270,
+        2: Image.Transpose.ROTATE_180,
+        3: Image.Transpose.ROTATE_90,
+    }
+
     def __init__(self, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> None:
         super().__init__(config, klippy, logging_handler)
         self._img_extension = "jpeg"
@@ -646,24 +652,13 @@ class MjpegCamera(Camera):
         self._host = config.camera.host
         self._host_snapshot = config.camera.host_snapshot or self._host.replace("stream", "snapshot")
 
-        self._rotate_code_mjpeg: Image.Transpose
-        if config.camera.rotate == "90_cw":
-            self._rotate_code_mjpeg = Image.Transpose.ROTATE_270
-        elif config.camera.rotate == "90_ccw":
-            self._rotate_code_mjpeg = Image.Transpose.ROTATE_90
-        elif config.camera.rotate == "180":
-            self._rotate_code_mjpeg = Image.Transpose.ROTATE_180
-        else:
-            self._rotate_code_mjpeg = None  # type: ignore[assignment]
-
     def _rotate_img(self, img: Image.Image) -> Image.Image:
-        if self._flip_vertically or self._flip_horizontally or self._rotate_code_mjpeg:
-            if self._flip_vertically:
-                img = img.transpose(Image.Transpose.FLIP_TOP_BOTTOM)
-            if self._flip_horizontally:
-                img = img.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
-            if self._rotate_code_mjpeg:
-                img = img.transpose(self._rotate_code_mjpeg)
+        if self._flip_vertically:
+            img = img.transpose(Image.Transpose.FLIP_TOP_BOTTOM)
+        if self._flip_horizontally:
+            img = img.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
+        if self._rotation_count is not None:
+            img = img.transpose(self._ROTATION_TO_TRANSPOSE[self._rotation_count])
         return img
 
     @cam_light_toggle
@@ -795,7 +790,7 @@ class RawStreamCamera(MjpegCamera):
     def __init__(self, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> None:
         super().__init__(config, klippy, logging_handler)
 
-        if self._flip_vertically or self._flip_horizontally or self._rotate_code > -10:
+        if self._flip_vertically or self._flip_horizontally or self._rotation_count is not None:
             logger.warning("raw_stream camera: flip/rotate not supported for video (stream copy). Use type=ffmpeg if you need video transforms.")
 
     @cam_light_toggle

--- a/bot/camera.py
+++ b/bot/camera.py
@@ -60,22 +60,22 @@ def cam_light_toggle(func: F) -> F:
 
         self.light_timer_event.wait()
 
-        # Todo: maybe add try block?
-        result = func(self, *args, **kwargs)
+        try:
+            result = func(self, *args, **kwargs)
+        finally:
+            self.free_light()
 
-        self.free_light()
+            def delayed_light_off() -> None:
+                if self.light_requests == 0:
+                    if self.light_lock.locked():
+                        self.light_lock.release()
+                    self.light_need_off = False
+                    self.light_device.turn_off_sync()
+                else:
+                    logger.debug("light requests count: %s", self.light_requests)
 
-        def delayed_light_off() -> None:
-            if self.light_requests == 0:
-                if self.light_lock.locked():
-                    self.light_lock.release()
-                self.light_need_off = False
-                self.light_device.turn_off_sync()
-            else:
-                logger.debug("light requests count: %s", self.light_requests)
-
-        if self.light_need_off and self.light_requests == 0:
-            threading.Timer(self.light_timeout, delayed_light_off).start()
+            if self.light_need_off and self.light_requests == 0:
+                threading.Timer(self.light_timeout, delayed_light_off).start()
 
         return result
 

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -203,6 +203,7 @@ class BotConfig(ConfigHelper):
         "log_parser",
         "power_device",
         "light_device",
+        "log_path",
         "upload_path",
         "services",
     ]
@@ -222,8 +223,7 @@ class BotConfig(ConfigHelper):
         self.light_device_name: str = self._get_str("light_device", default="")
         self.poweroff_device_name: str = self._get_str("power_device", default="")
         self.debug: bool = self._get_boolean("debug", default=False)
-        self.log_path: Path = Path(self._get_str("log_path", default="/tmp"))
-        self.log_file: Path = self.log_path
+        self.log_file: Path = Path(self._get_str("log_path", default="/tmp/telegram.log"))
         self.upload_path: str = self._get_str("upload_path", default="")
         self.services: list[str] = self._get_list("services", default=["klipper", "moonraker"])
         self.log_parser: bool = self._get_boolean("log_parser", default=False)
@@ -248,14 +248,13 @@ class BotConfig(ConfigHelper):
             return self.upload_path + "/"
         return self.upload_path
 
-    def log_path_update(self, logfile: str) -> None:
-        if logfile:
-            self.log_file = Path(logfile)
+    def resolve_log_path(self, cli_log_path: Path | None) -> None:
+        """Apply CLI override to log file path if provided."""
+        if cli_log_path is not None:
+            self.log_file = cli_log_path
         if not self.log_file.suffix:
             self.log_file = self.log_file / "telegram.log"
-        if str(self.log_file) != "/tmp" or str(self.log_file.parent) != "/tmp":
-            self.log_file.parent.mkdir(parents=True, exist_ok=True)
-        self.log_path = self.log_file.parent
+        self.log_file.parent.mkdir(parents=True, exist_ok=True)
 
 
 class CameraConfig(ConfigHelper):

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -229,10 +229,10 @@ class BotConfig(ConfigHelper):
         self.log_parser: bool = self._get_boolean("log_parser", default=False)
 
         host_parts = self.host.split(":")
-        if len(host_parts) == 2 and host_parts[1].isdigit():
+        if len(host_parts) == 2 and host_parts[1].isdigit():  # noqa: PLR2004
             self.host = host_parts[0]
             self.port = int(host_parts[1])
-        elif len(host_parts) >= 2:
+        elif len(host_parts) >= 2:  # noqa: PLR2004
             self._parsing_errors.append("Protocol must be specified in other configuration parameters")
 
         if self.http_proxy and self.socks_proxy:
@@ -320,7 +320,7 @@ class NotifierConfig(ConfigHelper):
     def _get_group_with_thread_id(self, group_id: str) -> tuple[int, int | None] | None:
         try:
             parts = group_id.split(":")
-            if len(parts) == 2:
+            if len(parts) == 2:  # noqa: PLR2004
                 return int(parts[0]), int(parts[1])
             if len(parts) == 1:
                 return int(parts[0]), None

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -223,7 +223,7 @@ class BotConfig(ConfigHelper):
         self.poweroff_device_name: str = self._get_str("power_device", default="")
         self.debug: bool = self._get_boolean("debug", default=False)
         self.log_path: Path = Path(self._get_str("log_path", default="/tmp"))
-        self.log_file: Path = Path(self._get_str("log_path", default="/tmp"))
+        self.log_file: Path = self.log_path
         self.upload_path: str = self._get_str("upload_path", default="")
         self.services: list[str] = self._get_list("services", default=["klipper", "moonraker"])
         self.log_parser: bool = self._get_boolean("log_parser", default=False)

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -429,10 +429,10 @@ class TelegramUIConfig(ConfigHelper):
                     map(
                         lambda iel: f"/{iel.strip()}",
                         el.replace("[", "").replace("]", "").split(","),
-                    )
+                    ),
                 ),
                 re.findall(r"\[.[^\]]*\]", self._get_str("buttons", default="[pause,cancel,resume],[status,files,macros],[fw_restart,emergency,shutdown,services]")),
-            )
+            ),
         )
         self.progress_update_message: bool = self._get_boolean("progress_update_message", default=False)
         self.send_reply_keyboard: bool = self._get_boolean("send_reply_keyboard", default=True)
@@ -448,7 +448,8 @@ class TelegramUIConfig(ConfigHelper):
         self.send_greeting_message: bool = self._get_boolean("send_greeting_message", default=True)
         self.status_update_button: bool = self._get_boolean("status_update_button", default=True)
         self.require_confirmation: list[str] = self._get_list(
-            "require_confirmation", default=["logs", "logs_upload", "shutdown", "restart", "cancel", "fw_restart", "emergency", "reboot", "power", "bot_restart"]
+            "require_confirmation",
+            default=["logs", "logs_upload", "shutdown", "restart", "cancel", "fw_restart", "emergency", "reboot", "power", "bot_restart"],
         )
 
     def is_present_in_require_confirmation(self, command: str) -> bool:

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -40,11 +40,11 @@ class ConfigHelper:
     def _check_numerical_value(
         self,
         option: str,
-        value: int | float,
-        above: int | float | None = None,
-        below: int | float | None = None,
-        min_value: int | float | None = None,
-        max_value: int | float | None = None,
+        value: float,
+        above: float | None = None,
+        below: float | None = None,
+        min_value: float | None = None,
+        max_value: float | None = None,
     ) -> None:
         if not self._config.has_option(self._section, option):
             return
@@ -85,10 +85,10 @@ class ConfigHelper:
         self,
         option: str,
         default: int | None = None,
-        above: int | float | None = None,
-        below: int | float | None = None,
-        min_value: int | float | None = None,
-        max_value: int | float | None = None,
+        above: float | None = None,
+        below: float | None = None,
+        min_value: float | None = None,
+        max_value: float | None = None,
     ) -> int:
         val: int = self._get_option_value(self._config.getint, option, default)
         self._check_numerical_value(option, val, above, below, min_value, max_value)
@@ -98,10 +98,10 @@ class ConfigHelper:
         self,
         option: str,
         default: float | None = None,
-        above: int | float | None = None,
-        below: int | float | None = None,
-        min_value: int | float | None = None,
-        max_value: int | float | None = None,
+        above: float | None = None,
+        below: float | None = None,
+        min_value: float | None = None,
+        max_value: float | None = None,
     ) -> float:
         val: float = self._get_option_value(self._config.getfloat, option, default)
         self._check_numerical_value(option, val, above, below, min_value, max_value)

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -15,7 +15,7 @@ class ConfigHelper:
     _section: str
     _KNOWN_ITEMS: ClassVar[list[str]]
 
-    def __init__(self, config: configparser.ConfigParser):
+    def __init__(self, config: configparser.ConfigParser) -> None:
         self._config = config
         self._parsing_errors: list[str] = []
 
@@ -151,7 +151,7 @@ class SecretsConfig(ConfigHelper):
         "proxy_password",
     ]
 
-    def __init__(self, config: configparser.ConfigParser):
+    def __init__(self, config: configparser.ConfigParser) -> None:
         secrets_path = Path(config.get("secrets", "secrets_path", fallback="")).expanduser()
         secrets_path_default_name = (secrets_path / "secrets.conf").expanduser()
         conf = configparser.ConfigParser(allow_no_value=True, inline_comment_prefixes=(";", "#"))
@@ -208,7 +208,7 @@ class BotConfig(ConfigHelper):
         "services",
     ]
 
-    def __init__(self, config: configparser.ConfigParser):
+    def __init__(self, config: configparser.ConfigParser) -> None:
         super().__init__(config)
 
         # Todo: validate server addr have ho port or protocol!
@@ -277,7 +277,7 @@ class CameraConfig(ConfigHelper):
         "type",
     ]
 
-    def __init__(self, config: configparser.ConfigParser):
+    def __init__(self, config: configparser.ConfigParser) -> None:
         super().__init__(config)
         self.enabled: bool = config.has_section(self._section)
         self.cam_type: str = self._get_str("type", default="mjpeg", allowed_values=["opencv", "ffmpeg", "mjpeg", "raw_stream"])
@@ -304,7 +304,7 @@ class NotifierConfig(ConfigHelper):
     _section = "progress_notification"
     _KNOWN_ITEMS: ClassVar[list[str]] = ["percent", "height", "time", "groups", "group_only"]
 
-    def __init__(self, config: configparser.ConfigParser):
+    def __init__(self, config: configparser.ConfigParser) -> None:
         super().__init__(config)
         self.enabled: bool = config.has_section(self._section)
         self.percent: int = self._get_int("percent", default=0, min_value=0)
@@ -354,7 +354,7 @@ class TimelapseConfig(ConfigHelper):
         "raw_compressed",
     ]
 
-    def __init__(self, config: configparser.ConfigParser):
+    def __init__(self, config: configparser.ConfigParser) -> None:
         super().__init__(config)
         self.enabled: bool = config.has_section(self._section)
         self.base_dir: Path = Path(self._get_str("basedir", default="~/moonraker-telegram-bot-timelapse"))
@@ -419,7 +419,7 @@ class TelegramUIConfig(ConfigHelper):
         "last_update_time",
     ]
 
-    def __init__(self, config: configparser.ConfigParser):
+    def __init__(self, config: configparser.ConfigParser) -> None:
         super().__init__(config)
         self.eta_source: str = self._get_str("eta_source", default="slicer", allowed_values=["slicer", "file"])
         self.buttons_default: bool = bool(not config.has_option(self._section, "buttons"))
@@ -482,7 +482,7 @@ class StatusMessageContentConfig(ConfigHelper):
         "last_update_time",
     ]
 
-    def __init__(self, config: configparser.ConfigParser):
+    def __init__(self, config: configparser.ConfigParser) -> None:
         super().__init__(config)
         self.content: list[str] = self._get_list("content", default=self._MESSAGE_CONTENT, allowed_values=self._MESSAGE_CONTENT)
         self.sensors: list[str] = self._get_list("sensors", default=[])
@@ -494,7 +494,7 @@ class StatusMessageContentConfig(ConfigHelper):
 class ConfigWrapper:
     """Top-level config loader that parses telegram.conf and assembles section configs."""
 
-    def __init__(self, path: Path):
+    def __init__(self, path: Path) -> None:
         config = configparser.ConfigParser(allow_no_value=True, inline_comment_prefixes=(";", "#"))
         config.read(path)
 

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -494,14 +494,14 @@ class StatusMessageContentConfig(ConfigHelper):
 class ConfigWrapper:
     """Top-level config loader that parses telegram.conf and assembles section configs."""
 
-    def __init__(self, path: str):
+    def __init__(self, path: Path):
         config = configparser.ConfigParser(allow_no_value=True, inline_comment_prefixes=(";", "#"))
         config.read(path)
 
         for sec in config.sections():
             if sec.startswith("include"):
                 addit_conf = sec.replace("include", "").strip()
-                config.read(Path(path).parent.joinpath(addit_conf))
+                config.read(path.parent / addit_conf)
 
         self._config = config
         self.secrets = SecretsConfig(config)

--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -105,9 +105,9 @@ class Klippy:
 
     _DATA_MACRO: Final = "bot_data"
 
-    _SENSOR_PARAMS: Final = {"temperature": "temperature", "target": "target", "power": "power", "speed": "speed", "rpm": "rpm"}
+    _SENSOR_PARAMS: Final = ["temperature", "target", "power", "speed", "rpm"]
 
-    _POWER_DEVICE_PARAMS: Final = {"device": "device", "status": "status", "locked_while_printing": "locked_while_printing", "type": "type", "is_shutdown": "is_shutdown"}
+    _POWER_DEVICE_PARAMS: Final = ["device", "status", "locked_while_printing", "type", "is_shutdown"]
 
     def __init__(
         self,
@@ -410,9 +410,9 @@ class Klippy:
     def update_sensor(self, name: str, value: dict[str, Any]) -> None:
         if name not in self._sensors_dict:
             self._sensors_dict[name] = {}
-        for key, val in self._SENSOR_PARAMS.items():
+        for key in self._SENSOR_PARAMS:
             if key in value:
-                self._sensors_dict[name][key] = value[val]
+                self._sensors_dict[name][key] = value[key]
 
     @staticmethod
     def _sensor_message(name: str, value: dict[str, Any]) -> str:
@@ -444,9 +444,9 @@ class Klippy:
     def update_power_device(self, name: str, value: dict[str, Any]) -> None:
         if name not in self._power_devices:
             self._power_devices[name] = {}
-        for key, val in self._POWER_DEVICE_PARAMS.items():
+        for key in self._POWER_DEVICE_PARAMS:
             if key in value:
-                self._power_devices[name][key] = value[val]
+                self._power_devices[name][key] = value[key]
 
     @staticmethod
     def _device_message(name: str, value: dict[str, Any], emoji_symbol: str = ":vertical_traffic_light:") -> str:

--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -453,7 +453,7 @@ class Klippy:
         message = emoji.emojize(f" {emoji_symbol} ", language="alias") + f"{name}: "
         if "status" in value:
             message += f" {value['status']} "
-        if "locked_while_printing" in value and value["locked_while_printing"] == "True":
+        if value.get("locked_while_printing"):
             message += emoji.emojize(" :lock: ", language="alias")
         if message:
             message += "\n"

--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -235,18 +235,18 @@ class Klippy:
     # Todo: save macros list until klippy restart
     @property
     def macros(self) -> list[str]:
-        return self._get_marco_list()
+        return self._get_macro_list()
 
     async def get_macros_force(self) -> list[str]:
         try:
             await self._update_printer_objects()
         except Exception:
             logger.exception("Failed to get macros force")
-        return self._get_marco_list()
+        return self._get_macro_list()
 
     @property
     def macros_all(self) -> list[str]:
-        return self._get_full_marco_list()
+        return self._get_full_macro_list()
 
     @property
     def moonraker_host(self) -> str:
@@ -340,12 +340,12 @@ class Klippy:
     def printing_filename_with_time(self) -> str:
         return f"{self._printing_filename}_{datetime.fromtimestamp(self.file_print_start_time):%Y-%m-%d_%H-%M}"
 
-    def _get_full_marco_list(self) -> list[str]:
+    def _get_full_macro_list(self) -> list[str]:
         macro_lines = list(filter(lambda it: "gcode_macro" in it, self._objects_list))
         return [el.split(" ")[1].upper() for el in macro_lines]
 
-    def _get_marco_list(self) -> list[str]:
-        return [key for key in self._get_full_marco_list() if key not in self._hidden_macros and (True if self._show_private_macros else not key.startswith("_"))]
+    def _get_macro_list(self) -> list[str]:
+        return [key for key in self._get_full_macro_list() if key not in self._hidden_macros and (True if self._show_private_macros else not key.startswith("_"))]
 
     async def _auth_moonraker(self) -> None:
         if not self._user or not self._passwd:
@@ -694,12 +694,12 @@ class Klippy:
             logger.error("Failed getting %s from %s \n\n%s", param_name, self._dbname, res)
 
     # macro data section
-    async def save_data_to_marco(self, lapse_size: int, filename: str, path: str) -> None:
-        full_macro_list = self._get_full_marco_list()
+    async def save_data_to_macro(self, lapse_size: int, filename: str, path: str) -> None:
+        full_macro_list = self._get_full_macro_list()
         if self._DATA_MACRO in full_macro_list:
             await self.execute_gcode_script(f"SET_GCODE_VARIABLE MACRO=bot_data VARIABLE=lapse_video_size VALUE={lapse_size}")
             await self.execute_gcode_script(f"SET_GCODE_VARIABLE MACRO=bot_data VARIABLE=lapse_filename VALUE='\"{filename}\"'")
             await self.execute_gcode_script(f"SET_GCODE_VARIABLE MACRO=bot_data VARIABLE=lapse_path VALUE='\"{path}\"'")
 
         else:
-            logger.error("Marco %s not defined", self._DATA_MACRO)
+            logger.error("Macro %s not defined", self._DATA_MACRO)

--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -108,6 +108,7 @@ class Klippy:
     _SENSOR_PARAMS: Final = ["temperature", "target", "power", "speed", "rpm"]
 
     _POWER_DEVICE_PARAMS: Final = ["device", "status", "locked_while_printing", "type", "is_shutdown"]
+    _MAX_CONNECT_RETRIES: Final = 10
 
     def __init__(
         self,
@@ -376,7 +377,7 @@ class Klippy:
 
     async def make_request(self, method: str, url_path: str, json: Any = None, files: Any = None, timeout: int = 30) -> httpx.Response:
         res = await self._client.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=self._headers, files=files, timeout=timeout)
-        if res.status_code == 401:  # Unauthorized
+        if res.status_code == httpx.codes.UNAUTHORIZED:
             logger.debug("JWT token expired, refreshing...")
             await self._refresh_moonraker_token()
             res = await self._client.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=self._headers, files=files, timeout=timeout)
@@ -392,7 +393,7 @@ class Klippy:
         connected = False
         retries = 0
         last_reason = ""
-        while not connected and retries < 10:
+        while not connected and retries < self._MAX_CONNECT_RETRIES:
             try:
                 response = await self.make_request("GET", "/printer/info", timeout=3)
                 connected = response.is_success
@@ -417,6 +418,7 @@ class Klippy:
 
     @staticmethod
     def _sensor_message(name: str, value: dict[str, Any]) -> str:
+        temp_display_threshold: Final = 2
         sens_name = re.sub(r"([A-Z]|\d|_)", r" \1", name).replace("_", "")
         message = ""
 
@@ -431,7 +433,7 @@ class Klippy:
 
         if "temperature" in value:
             message += f" {round(value['temperature'])} \N{DEGREE SIGN}C"
-        if "target" in value and value["target"] > 0.0 and abs(value["target"] - value["temperature"]) > 2:
+        if "target" in value and value["target"] > 0.0 and abs(value["target"] - value["temperature"]) > temp_display_threshold:
             message += emoji.emojize(" :arrow_right: ", language="alias") + f"{round(value['target'])} \N{DEGREE SIGN}C"
         if "power" in value and value["power"] > 0.0:
             message += emoji.emojize(" :fire:", language="alias")

--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -175,7 +175,8 @@ class Klippy:
         await self._auth_moonraker()
 
     def call_async(self, coro: Coroutine[Any, Any, T]) -> T:
-        assert self._loop is not None, "Event loop not set. Call async_init() first."
+        if self._loop is None:
+            raise RuntimeError("Event loop not set. Call async_init() first.")
         return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
 
     def prepare_sens_dict_subscribe(self) -> dict[str, Any]:

--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -113,7 +113,7 @@ class Klippy:
         self,
         config: ConfigWrapper,
         logging_handler: logging.Handler,
-    ):
+    ) -> None:
         self._protocol: str = "https" if config.bot_config.ssl else "http"
         self._host: str = f"{self._protocol}://{config.bot_config.host}:{config.bot_config.port}"
         self._ssl_verify: bool = config.bot_config.ssl_verify

--- a/bot/main.py
+++ b/bot/main.py
@@ -130,7 +130,7 @@ a_scheduler = AsyncIOScheduler(
     {
         "apscheduler.job_defaults.coalesce": "false",
         "apscheduler.job_defaults.max_instances": "4",
-    }
+    },
 )
 a_scheduler.add_listener(errors_listener, EVENT_JOB_ERROR)
 
@@ -213,16 +213,16 @@ async def check_unfinished_lapses(bot: telegram.Bot) -> None:
             InlineKeyboardButton(
                 emoji.emojize(":no_entry_sign: ", language="alias"),
                 callback_data="do_nothing",
-            )
-        ]
+            ),
+        ],
     )
     files_keys.append(
         [
             InlineKeyboardButton(
                 emoji.emojize(":wastebasket: Cleanup unfinished", language="alias"),
                 callback_data="cleanup_timelapse_unfinished",
-            )
-        ]
+            ),
+        ],
     )
     await bot.send_message(
         config_wrap.secrets.chat_id,
@@ -303,7 +303,7 @@ def confirm_keyboard(callback_mess: str) -> InlineKeyboardMarkup:
                 emoji.emojize(":no_entry_sign: ", language="alias"),
                 callback_data="do_nothing",
             ),
-        ]
+        ],
     ]
     return InlineKeyboardMarkup(keyboard)
 
@@ -347,25 +347,45 @@ async def command_exec(effective_message: Message, exec_text: str, exec_func: Co
 
 async def pause_printing(update: Update, __: ContextTypes.DEFAULT_TYPE) -> None:
     await command_confirm_message_ext(
-        update=update, command="pause", confirm_text="Pause printing?", exec_text="Pausing printing", callback_mess="pause_printing", exec_func=ws_helper.manage_printing("pause")
+        update=update,
+        command="pause",
+        confirm_text="Pause printing?",
+        exec_text="Pausing printing",
+        callback_mess="pause_printing",
+        exec_func=ws_helper.manage_printing("pause"),
     )
 
 
 async def resume_printing(update: Update, __: ContextTypes.DEFAULT_TYPE) -> None:
     await command_confirm_message_ext(
-        update=update, command="resume", confirm_text="Resume printing?", exec_text="Resuming printing", callback_mess="resume_printing", exec_func=ws_helper.manage_printing("resume")
+        update=update,
+        command="resume",
+        confirm_text="Resume printing?",
+        exec_text="Resuming printing",
+        callback_mess="resume_printing",
+        exec_func=ws_helper.manage_printing("resume"),
     )
 
 
 async def cancel_printing(update: Update, __: ContextTypes.DEFAULT_TYPE) -> None:
     await command_confirm_message_ext(
-        update=update, command="cancel", confirm_text="Cancel printing?", exec_text="Canceling printing", callback_mess="cancel_printing", exec_func=ws_helper.manage_printing("cancel")
+        update=update,
+        command="cancel",
+        confirm_text="Cancel printing?",
+        exec_text="Canceling printing",
+        callback_mess="cancel_printing",
+        exec_func=ws_helper.manage_printing("cancel"),
     )
 
 
 async def emergency_stop(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
     await command_confirm_message_ext(
-        update=update, command="emergency", confirm_text="Execute emergency stop?", exec_text="Executing emergency stop", callback_mess="emergency_stop", exec_func=ws_helper.emergency_stop_printer()
+        update=update,
+        command="emergency",
+        confirm_text="Execute emergency stop?",
+        exec_text="Executing emergency stop",
+        callback_mess="emergency_stop",
+        exec_func=ws_helper.emergency_stop_printer(),
     )
 
 
@@ -382,7 +402,12 @@ async def firmware_restart(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None
 
 async def shutdown_host(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
     await command_confirm_message_ext(
-        update=update, command="shutdown", confirm_text="Shutdown host?", exec_text="Shutting down host", callback_mess="shutdown_host", exec_func=ws_helper.shutdown_pi_host()
+        update=update,
+        command="shutdown",
+        confirm_text="Shutdown host?",
+        exec_text="Shutting down host",
+        callback_mess="shutdown_host",
+        exec_func=ws_helper.shutdown_pi_host(),
     )
 
 
@@ -621,7 +646,7 @@ async def button_lapse_handler(update: Update, context: ContextTypes.DEFAULT_TYP
         filter(
             lambda el: el[0].callback_data == query.data,
             query.message.reply_markup.inline_keyboard,
-        )
+        ),
     )[0].text
 
     info_mess: Message = await context.bot.send_message(
@@ -662,7 +687,7 @@ async def print_file_dialog_handler(update: Update, context: ContextTypes.DEFAUL
                 emoji.emojize(":cross_mark: cancel", language="alias"),
                 callback_data="cancel_file",
             ),
-        ]
+        ],
     ]
     start_pre_mess = "Start printing file:"
     message, bio = await klippy.get_file_info_by_name(pri_filename, f"{start_pre_mess}{pri_filename}?")
@@ -856,7 +881,7 @@ async def gcode_files_keyboard(offset: int = 0) -> InlineKeyboardMarkup:
             InlineKeyboardButton(
                 filename,
                 callback_data=f"{hashlib.md5(filename.encode()).hexdigest()}.gcode",
-            )
+            ),
         ]
 
     gcodes = await klippy.get_gcode_files()
@@ -868,20 +893,20 @@ async def gcode_files_keyboard(offset: int = 0) -> InlineKeyboardMarkup:
                 InlineKeyboardButton(
                     emoji.emojize(":arrow_backward:previous", language="alias"),
                     callback_data=f"gcode_files_offset:{offset - 10}",
-                )
+                ),
             )
         arrows.append(
             InlineKeyboardButton(
                 emoji.emojize(":no_entry_sign: ", language="alias"),
                 callback_data="do_nothing",
-            )
+            ),
         )
         if offset + 10 <= len(gcodes):
             arrows.append(
                 InlineKeyboardButton(
                     emoji.emojize("next:arrow_forward:", language="alias"),
                     callback_data=f"gcode_files_offset:{offset + 10}",
-                )
+                ),
             )
 
         files_keys += [arrows]
@@ -895,7 +920,7 @@ async def services_keyboard_no_confirm(effective_message: Message) -> None:
             InlineKeyboardButton(
                 element,
                 callback_data=f"rstrt_srvc:{element}" if config_wrap.telegram_ui.is_present_in_require_confirmation("services") else f"rstrt_srv:{element}",
-            )
+            ),
         ]
 
     services = config_wrap.bot_config.services
@@ -944,7 +969,7 @@ async def get_macros_no_confirm(effective_message: Message) -> None:
             InlineKeyboardButton(
                 el,
                 callback_data=(f"macroc:{el}" if config_wrap.telegram_ui.is_present_in_require_confirmation(el) or config_wrap.telegram_ui.confirm_macro() else f"macro:{el}"),
-            )
+            ),
         ]
         for el in klippy.macros
     ]
@@ -1076,7 +1101,8 @@ async def upload_file(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
             if await klippy.upload_gcode_file(sending_bio, config_wrap.bot_config.upload_path):
                 start_pre_mess = "Successfully uploaded file:"
                 mess, thumb = await klippy.get_file_info_by_name(
-                    f"{config_wrap.bot_config.formatted_upload_path}{sending_bio.name}", f"{start_pre_mess}{config_wrap.bot_config.formatted_upload_path}{sending_bio.name}"
+                    f"{config_wrap.bot_config.formatted_upload_path}{sending_bio.name}",
+                    f"{start_pre_mess}{config_wrap.bot_config.formatted_upload_path}{sending_bio.name}",
                 )
                 filehash = f"{hashlib.md5(doc.file_name.encode()).hexdigest()}.gcode"
                 keyboard = [
@@ -1089,7 +1115,7 @@ async def upload_file(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
                             emoji.emojize(":cross_mark: do nothing", language="alias"),
                             callback_data="do_nothing",
                         ),
-                    ]
+                    ],
                 ]
                 await update.effective_message.reply_photo(
                     photo=thumb,

--- a/bot/main.py
+++ b/bot/main.py
@@ -20,7 +20,7 @@ import socket
 import subprocess
 import sys
 import tarfile
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 import urllib.parse
 from zipfile import ZipFile
 
@@ -134,6 +134,9 @@ a_scheduler = AsyncIOScheduler(
 )
 a_scheduler.add_listener(errors_listener, EVENT_JOB_ERROR)
 
+_GCODE_FILES_PER_PAGE: Final = 10
+_MAX_BOT_COMMANDS: Final = 100
+
 config_wrap: ConfigWrapper
 main_pid = os.getpid()
 camera_wrap: Camera
@@ -184,11 +187,10 @@ async def status_no_confirm(effective_message: Message) -> None:
                 else:
                     await message.send_as_reply(effective_message, photo=bio)
                 bio.close()
+        elif is_inline_button_press:
+            await message.update_existing(effective_message)
         else:
-            if is_inline_button_press:
-                await message.update_existing(effective_message)
-            else:
-                await message.send_as_reply(effective_message)
+            await message.send_as_reply(effective_message)
 
 
 async def status(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
@@ -545,7 +547,7 @@ async def upload_logs_no_confirm(effective_message: Message) -> None:
 
     async with aiofiles.open(config_wrap.bot_config.log_file.parent / "logs.tar.xz", "rb") as log_archive_ojb, httpx.AsyncClient() as client_loc:
         resp = await client_loc.post(url="https://coderus.openrepos.net/klipper_logs", files={"tarfile": await log_archive_ojb.read()}, follow_redirects=False, timeout=25)
-        if resp.status_code < 400:
+        if not resp.is_error:
             logs_path = resp.headers["location"]
             logger.info(logs_path)
             await resp_message.edit_text(f"Logs are available at https://coderus.openrepos.net{logs_path}")
@@ -885,14 +887,14 @@ async def gcode_files_keyboard(offset: int = 0) -> InlineKeyboardMarkup:
         ]
 
     gcodes = await klippy.get_gcode_files()
-    files_keys: list[list[InlineKeyboardButton]] = list(map(create_file_button, gcodes[offset : offset + 10]))
-    if len(gcodes) > 10:
+    files_keys: list[list[InlineKeyboardButton]] = list(map(create_file_button, gcodes[offset : offset + _GCODE_FILES_PER_PAGE]))
+    if len(gcodes) > _GCODE_FILES_PER_PAGE:
         arrows = []
-        if offset >= 10:
+        if offset >= _GCODE_FILES_PER_PAGE:
             arrows.append(
                 InlineKeyboardButton(
                     emoji.emojize(":arrow_backward:previous", language="alias"),
-                    callback_data=f"gcode_files_offset:{offset - 10}",
+                    callback_data=f"gcode_files_offset:{offset - _GCODE_FILES_PER_PAGE}",
                 ),
             )
         arrows.append(
@@ -901,11 +903,11 @@ async def gcode_files_keyboard(offset: int = 0) -> InlineKeyboardMarkup:
                 callback_data="do_nothing",
             ),
         )
-        if offset + 10 <= len(gcodes):
+        if offset + _GCODE_FILES_PER_PAGE <= len(gcodes):
             arrows.append(
                 InlineKeyboardButton(
                     emoji.emojize("next:arrow_forward:", language="alias"),
-                    callback_data=f"gcode_files_offset:{offset + 10}",
+                    callback_data=f"gcode_files_offset:{offset + _GCODE_FILES_PER_PAGE}",
                 ),
             )
 
@@ -1097,43 +1099,42 @@ async def upload_file(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
                 disable_notification=notifier.silent_commands,
                 do_quote=True,
             )
+        elif await klippy.upload_gcode_file(sending_bio, config_wrap.bot_config.upload_path):
+            start_pre_mess = "Successfully uploaded file:"
+            mess, thumb = await klippy.get_file_info_by_name(
+                f"{config_wrap.bot_config.formatted_upload_path}{sending_bio.name}",
+                f"{start_pre_mess}{config_wrap.bot_config.formatted_upload_path}{sending_bio.name}",
+            )
+            filehash = f"{hashlib.md5(doc.file_name.encode()).hexdigest()}.gcode"
+            keyboard = [
+                [
+                    InlineKeyboardButton(
+                        emoji.emojize(":robot: print file", language="alias"),
+                        callback_data=f"print_file:{filehash}",
+                    ),
+                    InlineKeyboardButton(
+                        emoji.emojize(":cross_mark: do nothing", language="alias"),
+                        callback_data="do_nothing",
+                    ),
+                ],
+            ]
+            await update.effective_message.reply_photo(
+                photo=thumb,
+                caption=mess,
+                reply_markup=InlineKeyboardMarkup(keyboard),
+                disable_notification=notifier.silent_commands,
+                do_quote=True,
+                caption_entities=[MessageEntity(type="bold", offset=len(start_pre_mess), length=len(f"{config_wrap.bot_config.formatted_upload_path}{sending_bio.name}"))],
+            )
+            thumb.close()
+            # Todo: delete uploaded file
+            # bot.delete_message(update.effective_message.chat_id, update.effective_message.message_id)
         else:
-            if await klippy.upload_gcode_file(sending_bio, config_wrap.bot_config.upload_path):
-                start_pre_mess = "Successfully uploaded file:"
-                mess, thumb = await klippy.get_file_info_by_name(
-                    f"{config_wrap.bot_config.formatted_upload_path}{sending_bio.name}",
-                    f"{start_pre_mess}{config_wrap.bot_config.formatted_upload_path}{sending_bio.name}",
-                )
-                filehash = f"{hashlib.md5(doc.file_name.encode()).hexdigest()}.gcode"
-                keyboard = [
-                    [
-                        InlineKeyboardButton(
-                            emoji.emojize(":robot: print file", language="alias"),
-                            callback_data=f"print_file:{filehash}",
-                        ),
-                        InlineKeyboardButton(
-                            emoji.emojize(":cross_mark: do nothing", language="alias"),
-                            callback_data="do_nothing",
-                        ),
-                    ],
-                ]
-                await update.effective_message.reply_photo(
-                    photo=thumb,
-                    caption=mess,
-                    reply_markup=InlineKeyboardMarkup(keyboard),
-                    disable_notification=notifier.silent_commands,
-                    do_quote=True,
-                    caption_entities=[MessageEntity(type="bold", offset=len(start_pre_mess), length=len(f"{config_wrap.bot_config.formatted_upload_path}{sending_bio.name}"))],
-                )
-                thumb.close()
-                # Todo: delete uploaded file
-                # bot.delete_message(update.effective_message.chat_id, update.effective_message.message_id)
-            else:
-                await update.effective_message.reply_text(
-                    f"Failed uploading file: {sending_bio.name}",
-                    disable_notification=notifier.silent_commands,
-                    do_quote=True,
-                )
+            await update.effective_message.reply_text(
+                f"Failed uploading file: {sending_bio.name}",
+                disable_notification=notifier.silent_commands,
+                do_quote=True,
+            )
 
     uploaded_bio.close()
     sending_bio.close()
@@ -1228,9 +1229,9 @@ def prepare_commands_list(macros: list[str], add_macros: bool) -> list[Any]:
     commands = list(bot_commands().items())
     if add_macros:
         commands += list(filter(lambda el: el, map(prepare_command, macros)))  # type: ignore[arg-type]
-        if len(commands) >= 100:
+        if len(commands) >= _MAX_BOT_COMMANDS:
             logger.warning("Commands list too large!")
-            commands = commands[0:99]
+            commands = commands[0 : _MAX_BOT_COMMANDS - 1]
     return commands
 
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -468,7 +468,7 @@ def prepare_log_files() -> tuple[list[str], bool, str | None]:
                     debug_file.write(f"\n{file}\n")
                     with Path(file).open(encoding="utf-8") as file_obj:
                         debug_file.writelines(file_obj.readlines())
-            except Exception as err:
+            except Exception as err:  # noqa: PERF203
                 logger.warning(err)
 
     return ["telegram.log", "crowsnest.log", "moonraker.log", "klippy.log", "KlipperScreen.log", "dmesg.txt", "debug.txt"], dmesg_success, dmesg_error
@@ -495,7 +495,7 @@ async def send_logs_no_confirm(effective_message: Message) -> None:
                         logs_list.append(InputMediaDocument(content, filename=log_file))
                     else:
                         logger.debug("skipping empty log file: %s", log_file)
-        except FileNotFoundError as err:
+        except FileNotFoundError as err:  # noqa: PERF203
             logger.warning(err)
 
     if logs_list:
@@ -1359,7 +1359,7 @@ async def start_scheduler(context: ContextTypes.DEFAULT_TYPE) -> None:
     )
     # bot_updater.create_task(ws_helper.run_forever_async())
     loop = asyncio.get_event_loop()
-    loop.create_task(ws_helper.run_forever_async())
+    loop.create_task(ws_helper.run_forever_async())  # noqa: RUF006
 
 
 if __name__ == "__main__":

--- a/bot/main.py
+++ b/bot/main.py
@@ -397,7 +397,7 @@ async def bot_restart(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
 def prepare_log_files() -> tuple[list[str], bool, str | None]:
     dmesg_success = True
     dmesg_error = None
-    log_dir = config_wrap.bot_config.log_path
+    log_dir = config_wrap.bot_config.log_file.parent
 
     dmesg_file = log_dir / "dmesg.txt"
     if dmesg_file.exists():
@@ -455,7 +455,7 @@ async def send_logs_no_confirm(effective_message: Message) -> None:
         do_quote=True,
     )
 
-    log_dir = config_wrap.bot_config.log_path
+    log_dir = config_wrap.bot_config.log_file.parent
     logs_list: list[InputMediaAudio | InputMediaDocument | InputMediaPhoto | InputMediaVideo] = []
     for log_file in prepare_log_files()[0]:
         try:
@@ -477,7 +477,7 @@ async def send_logs_no_confirm(effective_message: Message) -> None:
         await effective_message.reply_media_group(logs_list, disable_notification=notifier.silent_commands, do_quote=True, write_timeout=120)
         await resp_message.edit_text(text=f"{await klippy.get_versions_info()}\nUpload logs to analyzer /logs_upload")
     else:
-        await resp_message.edit_text(text=f"No logs found in log_path `{config_wrap.bot_config.log_path}`")
+        await resp_message.edit_text(text=f"No logs found in log_path `{config_wrap.bot_config.log_file.parent}`")
 
 
 async def send_logs(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
@@ -503,7 +503,7 @@ async def upload_logs_no_confirm(effective_message: Message) -> None:
         await resp_message.edit_text(f"Dmesg log file creation error {dmesg_error}")
         return
 
-    log_dir = config_wrap.bot_config.log_path
+    log_dir = config_wrap.bot_config.log_file.parent
     archive_path = log_dir / "logs.tar.xz"
 
     if await anyio.Path(archive_path).exists():
@@ -518,7 +518,7 @@ async def upload_logs_no_confirm(effective_message: Message) -> None:
     await resp_message.edit_text("Uploading logs to parser")
     await effective_message.get_bot().send_chat_action(chat_id=config_wrap.secrets.chat_id, action=ChatAction.UPLOAD_DOCUMENT)
 
-    async with aiofiles.open(config_wrap.bot_config.log_path / "logs.tar.xz", "rb") as log_archive_ojb, httpx.AsyncClient() as client_loc:
+    async with aiofiles.open(config_wrap.bot_config.log_file.parent / "logs.tar.xz", "rb") as log_archive_ojb, httpx.AsyncClient() as client_loc:
         resp = await client_loc.post(url="https://coderus.openrepos.net/klipper_logs", files={"tarfile": await log_archive_ojb.read()}, follow_redirects=False, timeout=25)
         if resp.status_code < 400:
             logs_path = resp.headers["location"]
@@ -1345,6 +1345,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "-l",
         "--logfile",
+        type=Path,
+        default=None,
         metavar="<logfile>",
         help="Location of moonraker telegram bot log file",
     )
@@ -1353,7 +1355,7 @@ if __name__ == "__main__":
     os.chdir(sys.path[0])
 
     config_wrap = ConfigWrapper(system_args.configfile)
-    config_wrap.bot_config.log_path_update(system_args.logfile)
+    config_wrap.bot_config.resolve_log_path(system_args.logfile)
     config_wrap.dump_config_to_log()
 
     rotating_handler = RotatingFileHandler(

--- a/bot/main.py
+++ b/bot/main.py
@@ -1338,7 +1338,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "-c",
         "--configfile",
-        default="./telegram.conf",
+        type=Path,
+        default=Path("./telegram.conf"),
         metavar="<configfile>",
         help="Location of moonraker telegram bot configuration file",
     )

--- a/bot/main.py
+++ b/bot/main.py
@@ -975,7 +975,7 @@ async def macros_handler(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
     if command in klippy.macros_all:
         if config_wrap.telegram_ui.is_present_in_require_confirmation(command):
             await update.effective_message.reply_text(
-                f"Execute marco {command}?",
+                f"Execute macro {command}?",
                 reply_markup=confirm_keyboard(f"macro:{command}"),
                 disable_notification=notifier.silent_commands,
                 do_quote=True,
@@ -1184,15 +1184,15 @@ async def help_command(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
         await help_command_no_confirm(update.effective_message)
 
 
-def prepare_command(marco: str) -> BotCommand | None:
-    if re.match("^[a-zA-Z0-9_]{1,32}$", marco):
+def prepare_command(macro: str) -> BotCommand | None:
+    if re.match("^[a-zA-Z0-9_]{1,32}$", macro):
         try:
-            return BotCommand(marco.lower(), marco)
+            return BotCommand(macro.lower(), macro)
         except Exception:
-            logger.exception("Bad macro name '%s'", marco)
+            logger.exception("Bad macro name '%s'", macro)
             return None
     else:
-        logger.warning("Bad macro name '%s'", marco)
+        logger.warning("Bad macro name '%s'", macro)
         return None
 
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -736,7 +736,8 @@ async def button_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         await query.delete_message()
         await command_exec(effective_message=update.effective_message.reply_to_message, exec_text="Restarting bot", exec_func=restart_bot())
     elif query.data == "power_off_printer":
-        assert psu_power_device is not None
+        if psu_power_device is None:
+            return
         await psu_power_device.turn_off()
         if psu_power_device.device_error:
             mess = f"Device `{psu_power_device.name}` failed to toggle off\nError: {psu_power_device.device_error}"
@@ -748,7 +749,8 @@ async def button_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             do_quote=True,
         )
     elif query.data == "power_on_printer":
-        assert psu_power_device is not None
+        if psu_power_device is None:
+            return
         await psu_power_device.turn_on()
         if psu_power_device.device_error:
             mess = f"Device `{psu_power_device.name}` failed to toggle on\nError: {psu_power_device.device_error}"
@@ -1406,7 +1408,8 @@ if __name__ == "__main__":
 
     ws_helper = WebSocketHelper(config_wrap, klippy, notifier, timelapse, a_scheduler, rotating_handler)
 
-    assert bot_updater.job_queue is not None
+    if bot_updater.job_queue is None:
+        raise RuntimeError("job_queue is not initialized")
     bot_updater.job_queue.run_once(start_scheduler, 1)
     bot_updater.run_polling(allowed_updates=Update.ALL_TYPES)
 

--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -148,9 +148,9 @@ class Notifier:
                         InlineKeyboardButton(
                             text="Update",
                             callback_data="updstatus",
-                        )
-                    ]
-                ]
+                        ),
+                    ],
+                ],
             )
         return inline_keyboard
 
@@ -691,10 +691,10 @@ class Notifier:
                             parse_button,
                             re.findall(r"\{.[^\}]*\}", el),
                         ),
-                    )
+                    ),
                 ),
                 re.findall(r"\[.[^\]]*\]", message),
-            )
+            ),
         )
 
         title_mathc = re.search(r"message\s*=\s*\'(.[^\']*)\'", message)

--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -662,7 +662,7 @@ class Notifier:
                     response += f"time={self.interval} "
                 else:
                     await self._klippy.execute_gcode_script(f'RESPOND PREFIX="Notification params error" MSG="unknown param `{part}`"')
-            except Exception as ex:
+            except Exception as ex:  # noqa: PERF203
                 await self._klippy.execute_gcode_script(f'RESPOND PREFIX="Notification params error" MSG="Failed parsing `{part}`. {ex}"')
         if response:
             full_conf = f"percent={self.percent} height={self.height} time={self.interval} "

--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -530,13 +530,12 @@ class Notifier:
                 async with aiofiles.open(path_obj, "rb") as fh:
                     bio.write(await fh.read())
                 bio.seek(0)
-                if bio.getbuffer().nbytes > 10485760:
-                    await self._bot.send_message(self._chat_id, text=f"Telegram bots have a 10mb filesize restriction for images, image couldn't be uploaded: `{path}`")
+                if bio.getbuffer().nbytes > self._max_upload_file_size * 1024 * 1024:
+                    await self._bot.send_message(self._chat_id, text=f"Telegram bots have a {self._max_upload_file_size}mb filesize restriction, image couldn't be uploaded: `{path}`")
+                elif not photos_list:
+                    photos_list.append(InputMediaPhoto(bio, filename=bio.name, caption=message))
                 else:
-                    if not photos_list:
-                        photos_list.append(InputMediaPhoto(bio, filename=bio.name, caption=message))
-                    else:
-                        photos_list.append(InputMediaPhoto(bio, filename=bio.name))
+                    photos_list.append(InputMediaPhoto(bio, filename=bio.name))
                 bio.close()
 
             await self._bot.send_media_group(
@@ -576,11 +575,10 @@ class Notifier:
                 bio.seek(0)
                 if bio.getbuffer().nbytes > self._max_upload_file_size * 1024 * 1024:
                     await self._bot.send_message(self._chat_id, text=f"Telegram bots have a {self._max_upload_file_size}mb filesize restriction, video couldn't be uploaded: `{path}`")
+                elif not photos_list:
+                    photos_list.append(InputMediaVideo(bio, filename=bio.name, caption=message))
                 else:
-                    if not photos_list:
-                        photos_list.append(InputMediaVideo(bio, filename=bio.name, caption=message))
-                    else:
-                        photos_list.append(InputMediaVideo(bio, filename=bio.name))
+                    photos_list.append(InputMediaVideo(bio, filename=bio.name))
                 bio.close()
 
             await self._bot.send_media_group(
@@ -621,11 +619,10 @@ class Notifier:
                 bio.seek(0)
                 if bio.getbuffer().nbytes > self._max_upload_file_size * 1024 * 1024:
                     await self._bot.send_message(self._chat_id, text=f"Telegram bots have a {self._max_upload_file_size}mb filesize restriction, document couldn't be uploaded: `{path}`")
+                elif not photos_list:
+                    photos_list.append(InputMediaDocument(bio, filename=bio.name, caption=message))
                 else:
-                    if not photos_list:
-                        photos_list.append(InputMediaDocument(bio, filename=bio.name, caption=message))
-                    else:
-                        photos_list.append(InputMediaDocument(bio, filename=bio.name))
+                    photos_list.append(InputMediaDocument(bio, filename=bio.name))
                 bio.close()
 
             await self._bot.send_media_group(

--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -39,7 +39,7 @@ class Notifier:
         camera_wrapper: Camera,
         scheduler: BaseScheduler,
         logging_handler: logging.Handler,
-    ):
+    ) -> None:
         self._bot: Bot = bot
         self._chat_id: int = config.secrets.chat_id
         self._cam_wrap: Camera = camera_wrapper

--- a/bot/timelapse.py
+++ b/bot/timelapse.py
@@ -194,7 +194,7 @@ class Timelapse:
         elif self._running:
             self._add_timelapse_timer()
 
-    def take_lapse_photo(self, position_z: float = -1001, manually: bool = False, gcode: bool = False) -> None:
+    def take_lapse_photo(self, position_z: float | None = None, manually: bool = False, gcode: bool = False) -> None:
         if not self._enabled:
             logger.debug("lapse is disabled")
             return
@@ -213,11 +213,11 @@ class Timelapse:
 
         gcode_command = self._after_photo_gcode if gcode and self._after_photo_gcode else ""
 
-        if self._height > 0.0 and (position_z >= self._last_height + self._height or 0.0 < position_z < self._last_height - self._height):
+        if position_z is None:
+            self._executors_pool.submit(self._camera.take_lapse_photo, gcode=gcode_command).add_done_callback(logging_callback)
+        elif self._height > 0.0 and (position_z >= self._last_height + self._height or 0.0 < position_z < self._last_height - self._height):
             self._executors_pool.submit(self._camera.take_lapse_photo, gcode=gcode_command).add_done_callback(logging_callback)
             self._last_height = position_z
-        elif position_z < -1000:
-            self._executors_pool.submit(self._camera.take_lapse_photo, gcode=gcode_command).add_done_callback(logging_callback)
 
     def take_test_lapse_photo(self) -> None:
         self._executors_pool.submit(self._camera.take_lapse_photo).add_done_callback(logging_callback)

--- a/bot/timelapse.py
+++ b/bot/timelapse.py
@@ -43,7 +43,7 @@ class Timelapse:
         scheduler: BaseScheduler,
         bot: Bot,
         logging_handler: logging.Handler,
-    ):
+    ) -> None:
         self._enabled: bool = config.timelapse.enabled and camera.enabled
         self._mode_manual: bool = config.timelapse.mode_manual
         self._height: float = config.timelapse.height

--- a/bot/timelapse.py
+++ b/bot/timelapse.py
@@ -296,7 +296,7 @@ class Timelapse:
 
             if self._after_lapse_gcode and gcode_name_out is not None:
                 # Todo: add exception handling
-                await self._klippy.save_data_to_marco(video_bio_nbytes, video_path, f"{gcode_name}.mp4")
+                await self._klippy.save_data_to_macro(video_bio_nbytes, video_path, f"{gcode_name}.mp4")
                 await self._klippy.execute_gcode_script(self._after_lapse_gcode.strip())
         except Exception as ex:
             logger.warning("Failed to send time-lapse to telegram bot: %s", ex)

--- a/bot/timelapse.py
+++ b/bot/timelapse.py
@@ -386,7 +386,7 @@ class Timelapse:
                     response += f"after_photo_gcode={self._after_photo_gcode} "
                 else:
                     await self._klippy.execute_gcode_script(f'RESPOND PREFIX="Timelapse params error" MSG="unknown param `{part}`"')
-            except Exception as ex:
+            except Exception as ex:  # noqa: PERF203
                 await self._klippy.execute_gcode_script(f'RESPOND PREFIX="Timelapse params error" MSG="Failed parsing `{part}`. {ex}"')
         if response:
             full_conf = (

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -22,6 +22,8 @@ from websockets.protocol import State
 from klippy import Klippy, PrintState
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from apscheduler.schedulers.base import BaseScheduler  # type: ignore[import-untyped]
 
     from configuration import ConfigWrapper
@@ -75,6 +77,7 @@ class WebSocketHelper:
         self._timelapse: Timelapse = timelapse
         self._scheduler: BaseScheduler = scheduler
         self._log_parser: bool = config.bot_config.log_parser
+        self._log_file: Path = config.bot_config.log_file
 
         self._ws: ClientConnection
         self._pending_requests: dict[int, str] = {}
@@ -426,7 +429,7 @@ class WebSocketHelper:
         await self._send_jsonrpc("printer.gcode.script", {"script": gcode})
 
     async def parselog(self) -> None:
-        async with aiofiles.open("../telegram.log", encoding="utf-8") as file:
+        async with aiofiles.open(self._log_file, encoding="utf-8") as file:
             lines = await file.readlines()
 
         wslines = list(filter(lambda it: " - b'{" in it, lines))
@@ -437,6 +440,9 @@ class WebSocketHelper:
             await anyio.sleep(0.01)
 
     async def run_forever_async(self) -> None:
+        if self._log_parser:
+            await self.parselog()
+
         # Todo: use headers instead of inline token
         async for websocket in connect(
             uri=f"{self._protocol}://{self._host}:{self._port}/websocket{await self._klippy.get_one_shot_token()}",

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from functools import wraps
 import logging
 import os
-import random
 import ssl
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
@@ -81,6 +80,7 @@ class WebSocketHelper:
 
         self._ws: ClientConnection
         self._pending_requests: dict[int, str] = {}
+        self._request_id_counter: int = 0
 
         if config.bot_config.debug:
             logger.setLevel(logging.DEBUG)
@@ -94,7 +94,8 @@ class WebSocketHelper:
 
     @property
     def _next_request_id(self) -> int:
-        return random.randint(0, 300000)
+        self._request_id_counter += 1
+        return self._request_id_counter
 
     async def _send_jsonrpc(self, method: str, params: dict[str, Any] | None = None) -> None:
         request_id = self._next_request_id

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -62,7 +62,7 @@ class WebSocketHelper:
         timelapse: Timelapse,
         scheduler: BaseScheduler,
         logging_handler: logging.Handler,
-    ):
+    ) -> None:
         self._host: str = config.bot_config.host
         self._port = config.bot_config.port
         self._protocol: str = "wss" if config.bot_config.ssl else "ws"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ select = [
     "PLE",   # pylint error
     "PLW",   # pylint warning
     "PTH",   # flake8-use-pathlib
+    "PYI",   # flake8-pyi
     "RET",   # flake8-return
     "RSE",   # flake8-raise
     "RUF",   # ruff-specific

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ select = [
     "RET",   # flake8-return
     "RSE",   # flake8-raise
     "RUF",   # ruff-specific
+    "S101",  # assert
     "SIM",   # flake8-simplify
     "SLF",   # flake8-self
     "T20",   # flake8-print
@@ -113,6 +114,7 @@ ignore = [
     "RUF006",  # fire-and-forget asyncio task — existing pattern
     "SIM108",  # ternary — would produce very long lines
     "TD",      # flake8-todos
+    "TRY003",  # long exception messages — not worth extracting
 ]
 [tool.ruff.lint.isort]
 force-sort-within-sections = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,14 @@ select = [
     "W",     # pycodestyle warnings
 ]
 ignore = [
+    # formatter-handled rules (https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules)
+    "D206",    # docstring-tab-indentation
+    "D300",    # triple-single-quotes
+    "E111",    # indentation-with-invalid-multiple
+    "E114",    # indentation-with-invalid-multiple-comment
+    "E117",    # over-indented
+    "W191",    # tab-indentation
+    # project-specific ignores
     "ANN401",  # any-type — too strict
     "D102",    # undocumented-public-method
     "D103",    # undocumented-public-function

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,9 +85,7 @@ select = [
     "PERF",  # perflint
     "PIE",   # flake8-pie
     "PT",    # flake8-pytest-style
-    "PLC",   # pylint convention
-    "PLE",   # pylint error
-    "PLW",   # pylint warning
+    "PL",    # pylint
     "PTH",   # flake8-use-pathlib
     "PYI",   # flake8-pyi
     "RET",   # flake8-return
@@ -122,6 +120,9 @@ ignore = [
     "D213",    # multi-line-summary-second-line (conflicts with D212)
     "E501",    # line length handled by formatter
     "PERF203", # try-except in loop — intentional error handling
+    "PLR0912", # too-many-branches
+    "PLR0913", # too-many-arguments
+    "PLR0915", # too-many-statements
     "RUF006",  # fire-and-forget asyncio task — existing pattern
     "SIM108",  # ternary — would produce very long lines
     "TD",      # flake8-todos
@@ -140,7 +141,7 @@ known-first-party = [
     "telegram_helper",
 ]
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = [ "D100", "S101", "S105", "SLF001" ]
+"tests/**/*.py" = [ "D100", "PLR2004", "S101", "S105", "SLF001" ]
 
 [tool.codespell]
 skip = "uv.lock"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,11 +65,12 @@ line-length = 200
 [tool.ruff.lint]
 select = [
     "A",     # flake8-builtins
-    "D",     # pydocstyle
+    "ANN",   # flake8-annotations
     "ARG",   # flake8-unused-arguments
     "ASYNC", # flake8-async
     "B",     # flake8-bugbear
     "C4",    # flake8-comprehensions
+    "D",     # pydocstyle
     "E",     # pycodestyle errors
     "F",     # pyflakes
     "FA",    # flake8-future-annotations
@@ -102,6 +103,7 @@ select = [
     "W",     # pycodestyle warnings
 ]
 ignore = [
+    "ANN401",  # any-type — too strict
     "D102",    # undocumented-public-method
     "D103",    # undocumented-public-function
     "D104",    # undocumented-public-package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,11 +119,9 @@ ignore = [
     "D203",    # incorrect-blank-line-before-class (conflicts with D211)
     "D213",    # multi-line-summary-second-line (conflicts with D212)
     "E501",    # line length handled by formatter
-    "PERF203", # try-except in loop — intentional error handling
     "PLR0912", # too-many-branches
     "PLR0913", # too-many-arguments
     "PLR0915", # too-many-statements
-    "RUF006",  # fire-and-forget asyncio task — existing pattern
     "SIM108",  # ternary — would produce very long lines
     "TD",      # flake8-todos
     "TRY003",  # long exception messages — not worth extracting

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -14,18 +14,18 @@ CONFIG_WITH_AUTH_PATH = "tests/resources/telegram_with_auth.conf"
 
 
 def test_template_config_has_no_errors() -> None:
-    config_path = pathlib.Path(CONFIG_TEMPLATE_PATH).absolute().as_posix()
+    config_path = pathlib.Path(CONFIG_TEMPLATE_PATH).absolute()
     assert ConfigWrapper(config_path).configuration_errors == ""
 
 
 def test_minimal_config_has_no_errors() -> None:
-    config_path = pathlib.Path(CONFIG_MINIMAL_PATH).absolute().as_posix()
+    config_path = pathlib.Path(CONFIG_MINIMAL_PATH).absolute()
     assert ConfigWrapper(config_path).configuration_errors == ""
 
 
 @pytest.fixture
 def config_secrets_helper() -> ConfigWrapper:
-    config_path = pathlib.Path(CONFIG_WITH_SECRETS_PATH).absolute().as_posix()
+    config_path = pathlib.Path(CONFIG_WITH_SECRETS_PATH).absolute()
     return ConfigWrapper(config_path)
 
 
@@ -40,7 +40,7 @@ def test_config_with_secrets_is_valid(config_secrets_helper: ConfigWrapper) -> N
 
 @pytest.fixture
 def config_helper() -> ConfigWrapper:
-    config_path = pathlib.Path(CONFIG_PATH).absolute().as_posix()
+    config_path = pathlib.Path(CONFIG_PATH).absolute()
     return ConfigWrapper(config_path)
 
 
@@ -55,7 +55,7 @@ def test_config_bot_is_valid(config_helper: ConfigWrapper) -> None:
 
 @pytest.fixture
 def config_with_auth(tmp_path: Path) -> ConfigWrapper:
-    config_path = pathlib.Path(CONFIG_WITH_AUTH_PATH).absolute().as_posix()
+    config_path = pathlib.Path(CONFIG_WITH_AUTH_PATH).absolute()
     wrapper = ConfigWrapper(config_path)
     wrapper.bot_config.log_file = tmp_path / "bot.log"
     return wrapper

--- a/tests/klippy_test.py
+++ b/tests/klippy_test.py
@@ -249,3 +249,15 @@ async def test_turn_on_sync_reports_error(mock_klippy: Klippy) -> None:
 
     assert result is False
     assert device.device_error == "device busy"
+
+
+def test_device_message_shows_lock_when_locked_while_printing() -> None:
+    value = {"status": "on", "locked_while_printing": True}
+    msg = Klippy._device_message("psu", value)
+    assert "🔒" in msg
+
+
+def test_device_message_no_lock_when_not_locked() -> None:
+    value = {"status": "on", "locked_while_printing": False}
+    msg = Klippy._device_message("psu", value)
+    assert "🔒" not in msg


### PR DESCRIPTION
## Bug fixes

- Fix `locked_while_printing` lock emoji never showing (bool vs string comparison)
- Reconnect `log_parser`, it was dropped during asyncio migration in 95832ea
- Release light lock on exception in `cam_light_toggle`
- Use config's `max_upload_file_size` for image size check (was hardcoded)
- Fix "marco" typo in messages, methods, and variables

## Improvements

- Rework log path: support `log_path` in config, CLI `-l` override, `Path` types
- Simplify `_SENSOR_PARAMS`/`_POWER_DEVICE_PARAMS` from identity dicts to lists
- Use incrementing counter for websocket request IDs instead of random
- Replace magic sentinel values with `None` for rotation and timelapse
- Skip docker CI job on forks
- Enable ruff rules: S101, ANN, PYI, PLR; ignore formatter-conflicting rules