### PR TITLE
Fix WebSocket auth failure on reconnect

### DIFF
--- a/bot/camera.py
+++ b/bot/camera.py
@@ -102,7 +102,7 @@ class Camera:
         self._stream_fps: int = config.camera.stream_fps
         self._klippy: Klippy = klippy
 
-        # Todo: refactor into timelapse class
+        # TODO: refactor into timelapse class
         self._base_dir: Path = config.timelapse.base_dir
         self._ready_dir: Path | None = config.timelapse.ready_dir
         self._cleanup: bool = config.timelapse.cleanup
@@ -153,8 +153,8 @@ class Camera:
         if config.bot_config.debug:
             logger.setLevel(logging.DEBUG)
 
-        # fixme: check init with NO opencv in other cameras!
-        # Fixme: deprecated! use T-API https://learnopencv.com/opencv-transparent-api/
+        # TODO: [fixme] check init with NO opencv in other cameras!
+        # TODO: [fixme] deprecated! use T-API https://learnopencv.com/opencv-transparent-api/
         if cv2:
             if config.bot_config.debug:
                 logger.debug(cv2.getBuildInformation())
@@ -378,7 +378,7 @@ class Camera:
 
             if not success:
                 logger.debug("failed to get camera frame for video")
-                # Todo: get picture from imgs?
+                # TODO: get picture from imgs?
 
             frame = process_video_frame(frame)
             height, width, channels = frame.shape
@@ -437,7 +437,7 @@ class Camera:
 
     def take_lapse_photo(self, gcode: str = "") -> None:
         logger.debug("Take_lapse_photo called with gcode `%s`", gcode)
-        # Todo: check for space available?
+        # TODO: check for space available?
         self.lapse_dir.mkdir(parents=True, exist_ok=True)
         # never add self in params there!
         raw_frame = self._take_raw_frame(rgb=False)
@@ -463,7 +463,7 @@ class Camera:
         # never add self in params there!
         if self._save_lapse_photos_as_images:
             with self.take_photo(raw_frame_rgb) as photo:
-                # Fixme: jpeg_low is bad file extension!
+                # TODO: [fixme] jpeg_low is bad file extension!
                 filename = self.lapse_dir / f"{time.time()}.{self._img_extension}"
                 with filename.open("wb") as outfile:
                     outfile.write(photo.getvalue())
@@ -573,7 +573,7 @@ class Camera:
 
         del raw_frames, img, layers, last_frame
 
-        # Todo: some error handling?
+        # TODO: some error handling?
 
         video_bytes: bytes = b""
 
@@ -610,11 +610,11 @@ class Camera:
             for filename in self.lapse_dir.iterdir():
                 filename.unlink()
 
-    # Todo: check if lapse was in subfolder ( alike gcode folders)
-    # Todo: refactor into timelapse class
-    # Todo: check for 64 symbols length in lapse names
+    # TODO: check if lapse was in subfolder ( alike gcode folders)
+    # TODO: refactor into timelapse class
+    # TODO: check for 64 symbols length in lapse names
     def detect_unfinished_lapses(self) -> list[str]:
-        # Todo: detect unstarted timelapse builds? folder with pics and no mp4 files
+        # TODO: detect unstarted timelapse builds? folder with pics and no mp4 files
         return [el.parent.name for el in self._base_dir.rglob("*.lock")]
 
     def cleanup_unfinished_lapses(self) -> None:
@@ -666,7 +666,7 @@ class MjpegCamera(Camera):
         bio = BytesIO()
         os_nice(15)
         try:
-            # Todo: speedup coonections?
+            # TODO: speedup coonections?
             response = httpx.get(f"{self._host_snapshot}", timeout=5, verify=False)
 
             os_nice(15)
@@ -692,7 +692,7 @@ class MjpegCamera(Camera):
 
     def take_lapse_photo(self, gcode: str = "") -> None:
         logger.debug("Take_lapse_photo called with gcode `%s`", gcode)
-        # Todo: check for space available?
+        # TODO: check for space available?
         self.lapse_dir.mkdir(parents=True, exist_ok=True)
         with self.take_photo(force_rotate=False) as photo:
             if gcode:
@@ -716,7 +716,7 @@ class MjpegCamera(Camera):
         del img
         return cast("NDArray[Any]", res[:, :, [2, 1, 0]].copy())
 
-    # Todo: apply frames rotation during ffmpeg call!
+    # TODO: apply frames rotation during ffmpeg call!
     def _get_frame(self, path: Path) -> NDArray[Any]:
         with path.open("rb") as image_file:
             buff = BytesIO(image_file.read())
@@ -734,7 +734,7 @@ class MjpegCamera(Camera):
             thumb_bio = self._create_thumb(frame)
             del frame, channels
 
-            # Todo: maybe there is another way to get fps from a streamer
+            # TODO: maybe there is another way to get fps from a streamer
             fps_cam = 15 if self._stream_fps == 0 else self._stream_fps
             frame_time = 1.0 / fps_cam
 

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -126,11 +126,11 @@ class ConfigHelper:
                     val = default
                 else:
                     val = []
-                    # Todo: raise some parsing exception
+                    # TODO: raise some parsing exception
         elif default is not None:
             val = default
         else:
-            # Todo: raise some parsing exception
+            # TODO: raise some parsing exception
             val = []
 
         self._check_list_values(option, val, allowed_values)
@@ -211,7 +211,7 @@ class BotConfig(ConfigHelper):
     def __init__(self, config: configparser.ConfigParser) -> None:
         super().__init__(config)
 
-        # Todo: validate server addr have ho port or protocol!
+        # TODO: validate server addr have ho port or protocol!
         self.host: str = self._get_str("server", default="localhost")
         self.ssl: bool = self._get_boolean("ssl", default=False)
         self.ssl_verify: bool = self._get_boolean("ssl_verify", default=True)
@@ -289,8 +289,9 @@ class CameraConfig(ConfigHelper):
         self.rotate: str = self._get_str("rotate", default="", allowed_values=["", "90_cw", "90_ccw", "180"])
         self.fourcc: str = self._get_str("fourcc", default="h264", allowed_values=["h264", "mpeg4"])
 
-        # self.threads: int = self._getint( "threads", fallback=int(len(os.sched_getaffinity(0)) / 2)) #Fixme:
-        self.threads: int = self._get_int("threads", default=2, min_value=0)  # Fixme: fix default calcs! add check max value cpu count
+        # TODO: [fixme] fix default calcs! add check max value cpu count
+        # self.threads: int = self._getint( "threads", fallback=int(len(os.sched_getaffinity(0)) / 2))
+        self.threads: int = self._get_int("threads", default=2, min_value=0)
 
         self.video_duration: int = self._get_int("video_duration", default=5, above=0)
         self.video_buffer_size: int = self._get_int("video_buffer_size", default=2, above=0)
@@ -365,8 +366,8 @@ class TimelapseConfig(ConfigHelper):
         self.interval: int = self._get_int("time", default=0, min_value=0)
         self.target_fps: int = self._get_int("target_fps", default=15, above=0)
         self.limit_fps: bool = self._get_boolean("limit_fps", default=False)
-        self.min_lapse_duration: int = self._get_int("min_lapse_duration", default=0, min_value=0)  # Todo: check if max_value is max_lapse_duration
-        self.max_lapse_duration: int = self._get_int("max_lapse_duration", default=0, min_value=0)  # Todo: check if min_value is more than min_lapse_duration
+        self.min_lapse_duration: int = self._get_int("min_lapse_duration", default=0, min_value=0)  # TODO: check if max_value is max_lapse_duration
+        self.max_lapse_duration: int = self._get_int("max_lapse_duration", default=0, min_value=0)  # TODO: check if min_value is more than min_lapse_duration
         self.last_frame_duration: int = self._get_int("last_frame_duration", default=5, min_value=0)
         self.after_lapse_gcode: str = self._get_str("after_lapse_gcode", default="")
         self.send_finished_lapse: bool = self._get_boolean("send_finished_lapse", default=True)

--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -255,28 +255,17 @@ class Klippy:
         return self._host
 
     @property
-    def _headers(self) -> dict[str, str]:
-        heads = {}
+    def auth_headers(self) -> dict[str, str]:
         if self._jwt_token:
-            heads = {"Authorization": f"Bearer {self._jwt_token}"}
-        elif self._api_token:
-            heads = {"X-Api-Key": self._api_token}
-        return heads
+            return {"Authorization": f"Bearer {self._jwt_token}"}
+        if self._api_token:
+            return {"X-Api-Key": self._api_token}
+        return {}
 
-    async def get_one_shot_token(self) -> str:
-        if (not self._user and not self._jwt_token) and not self._api_token:
-            return ""
-
-        resp = await self._client.get(f"{self._host}/access/oneshot_token", headers=self._headers, timeout=15)
-
-        try:
-            resp.raise_for_status()
-            res = f"?token={orjson.loads(resp.text)['result']}"
-        except httpx.HTTPError:
-            logger.exception("Failed to get one shot token async")
-            res = ""
-
-        return res
+    async def ensure_auth(self) -> None:
+        """Refresh JWT token if using user/password auth. No-op for API token."""
+        if self._refresh_token:
+            await self._refresh_moonraker_token()
 
     async def _update_printer_objects(self) -> None:
         resp = await self.make_request("GET", "/printer/objects/list")
@@ -376,11 +365,11 @@ class Klippy:
             logger.exception("Failed to refresh token")
 
     async def make_request(self, method: str, url_path: str, json: Any = None, files: Any = None, timeout: int = 30) -> httpx.Response:
-        res = await self._client.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=self._headers, files=files, timeout=timeout)
+        res = await self._client.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=self.auth_headers, files=files, timeout=timeout)
         if res.status_code == httpx.codes.UNAUTHORIZED:
             logger.debug("JWT token expired, refreshing...")
             await self._refresh_moonraker_token()
-            res = await self._client.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=self._headers, files=files, timeout=timeout)
+            res = await self._client.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=self.auth_headers, files=files, timeout=timeout)
 
         try:
             res.raise_for_status()

--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -158,7 +158,7 @@ class Klippy:
         self._jwt_token: str = ""
         self._refresh_token: str = ""
 
-        # Todo: create sensors class!!
+        # TODO: create sensors class!!
         self._objects_list: list[str] = []
         self._sensors_dict: dict[str, dict[str, Any]] = {}
         self._power_devices: dict[str, Any] = {}
@@ -189,7 +189,7 @@ class Klippy:
                 if elem.split(" ")[-1] == heat:
                     sens_dict[elem] = None
             for sens in self._sensors_list:
-                if elem.split(" ")[-1] == sens and "sensor" in elem:  # Todo: add adc\thermistor
+                if elem.split(" ")[-1] == sens and "sensor" in elem:  # TODO: add adc\thermistor
                     sens_dict[elem] = None
             for fan in self._fans_list:
                 if elem.split(" ")[-1] == fan and "fan" in elem:
@@ -234,7 +234,7 @@ class Klippy:
         self._reset_file_info()
         self._objects_list = []
 
-    # Todo: save macros list until klippy restart
+    # TODO: save macros list until klippy restart
     @property
     def macros(self) -> list[str]:
         return self._get_macro_list()
@@ -294,7 +294,7 @@ class Klippy:
     async def set_printing_filename(self, new_value: str) -> None:
         if new_value == self._printing_filename:
             logger.info("'filename' has the same value as the current: %s", new_value)
-            # Fixme: maybe we should reset file info on all filename updates?
+            # TODO: [fixme] maybe we should reset file info on all filename updates?
             self._reset_file_info()
             return
 
@@ -389,7 +389,7 @@ class Klippy:
 
                 if connected:
                     return ""
-                # Todo: get reason from error handler
+                # TODO: get reason from error handler
                 last_reason = f"{response.status_code}"
             except Exception:
                 logger.exception("Failed to check connection")
@@ -576,7 +576,7 @@ class Klippy:
         print_stats = resp_json["result"]["status"]["print_stats"]
         message = ""
 
-        # Todo: refactor!
+        # TODO: refactor!
         if print_stats["state"] == "printing":
             if not self.printing_filename:
                 await self.set_printing_filename(print_stats["filename"])
@@ -671,7 +671,7 @@ class Klippy:
         if res.is_success:
             return orjson.loads(res.text)["result"]["value"]
         logger.error("Failed getting %s from %s \n\n%s", param_name, self._dbname, res)
-        # Fixme: return default value? check for 404!
+        # TODO: [fixme] return default value? check for 404!
         return None
 
     async def save_param_to_db(self, param_name: str, value: Any) -> None:

--- a/bot/main.py
+++ b/bot/main.py
@@ -1053,7 +1053,7 @@ async def upload_file(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
         )
         return
 
-    # Todo: add context management!
+    # TODO: add context management!
     uploaded_bio = BytesIO()
     uploaded_bio.name = doc.file_name
     uploaded_bio.write(file_byte_array)
@@ -1127,7 +1127,7 @@ async def upload_file(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
                 caption_entities=[MessageEntity(type="bold", offset=len(start_pre_mess), length=len(f"{config_wrap.bot_config.formatted_upload_path}{sending_bio.name}"))],
             )
             thumb.close()
-            # Todo: delete uploaded file
+            # TODO: delete uploaded file
             # bot.delete_message(update.effective_message.chat_id, update.effective_message.message_id)
         else:
             await update.effective_message.reply_text(
@@ -1189,7 +1189,7 @@ def bot_commands() -> dict[str, str]:
 
 
 async def help_command_no_confirm(effective_message: Message) -> None:
-    ## Fixme: escape symbols???  from telegram.utils.helpers import escape
+    ## TODO: [fixme] escape symbols???  from telegram.utils.helpers import escape
     mess = (
         await klippy.get_versions_info(bot_only=True)
         + ("\n".join([f"/{c} - {a}" for c, a in bot_commands().items()]))

--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -397,7 +397,7 @@ class Notifier:
 
     def add_notifier_timer(self) -> None:
         if self._interval > 0:
-            # Todo: maybe check if job exists?
+            # TODO: maybe check if job exists?
             self._sched.add_job(
                 self._notify_by_time,
                 "interval",
@@ -424,7 +424,7 @@ class Notifier:
         await self.reset_notifications()
         self.remove_notifier_timer()
 
-    # Todo: refactor with TelegramMessageRepr class
+    # TODO: refactor with TelegramMessageRepr class
     async def _send_print_start_info(self) -> None:
         message, bio = await self._klippy.get_file_info(state=PrintState.START)
 
@@ -465,7 +465,7 @@ class Notifier:
                 max_instances=1,
                 replace_existing=True,
             )
-        # Todo: reset something? or check if reset by setting new filename?
+        # TODO: reset something? or check if reset by setting new filename?
 
     async def _send_print_finish(self) -> None:
         self._schedule_notification(state=PrintState.FINISH)

--- a/bot/telegram_helper.py
+++ b/bot/telegram_helper.py
@@ -76,7 +76,7 @@ class TelegramMessageRepr:
 
     async def update_existing(self, other_message: Message, photo: BytesIO | bytes | None = None) -> None:
         if photo:
-            # Fixme: check if media in message!
+            # TODO: [fixme] check if media in message!
             await other_message.edit_media(media=InputMediaPhoto(photo))
         if other_message.caption:
             await other_message.edit_caption(

--- a/bot/timelapse.py
+++ b/bot/timelapse.py
@@ -295,7 +295,7 @@ class Timelapse:
             gc.collect()
 
             if self._after_lapse_gcode and gcode_name_out is not None:
-                # Todo: add exception handling
+                # TODO: add exception handling
                 await self._klippy.save_data_to_macro(video_bio_nbytes, video_path, f"{gcode_name}.mp4")
                 await self._klippy.execute_gcode_script(self._after_lapse_gcode.strip())
         except Exception as ex:

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -2,20 +2,25 @@
 
 from __future__ import annotations
 
+import asyncio
 from functools import wraps
+from http import HTTPStatus
 import logging
 import os
 import ssl
+import traceback
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 import aiofiles
 import anyio
+import orjson
 
 os.environ.setdefault("WEBSOCKETS_MAX_LOG_SIZE", "1048576")
 os.environ.setdefault("WEBSOCKETS_BACKOFF_MAX_DELAY", "15.0")
 
-import orjson
 from websockets.asyncio.client import ClientConnection, connect
+from websockets.client import backoff
+from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK, InvalidStatus
 from websockets.protocol import State
 
 from klippy import Klippy, PrintState
@@ -33,6 +38,16 @@ JSONRPC_METHOD_NOT_FOUND = -32601
 
 # Methods that may not be available depending on Moonraker configuration
 _OPTIONAL_METHODS = frozenset({"machine.device_power.devices"})
+
+# HTTP status codes that indicate a transient server error worth retrying
+_RETRYABLE_HTTP_CODES = frozenset(
+    {
+        HTTPStatus.INTERNAL_SERVER_ERROR,
+        HTTPStatus.BAD_GATEWAY,
+        HTTPStatus.SERVICE_UNAVAILABLE,
+        HTTPStatus.GATEWAY_TIMEOUT,
+    }
+)
 
 logger = logging.getLogger(__name__)
 
@@ -89,8 +104,15 @@ class WebSocketHelper:
             logger.addHandler(logging_handler)
 
     @staticmethod
-    def on_error(error: Exception) -> None:
-        logger.error(error)
+    def _is_retryable(error: Exception) -> bool:
+        """Check if a connection error is transient and worth retrying.
+
+        Network errors and transient server errors (e.g. when moonraker
+        restarts) are retryable.  Everything else is fatal.
+        """
+        if isinstance(error, (OSError, TimeoutError)):
+            return True
+        return isinstance(error, InvalidStatus) and error.response.status_code in _RETRYABLE_HTTP_CODES
 
     @property
     def _next_request_id(self) -> int:
@@ -440,35 +462,61 @@ class WebSocketHelper:
             await self.websocket_to_message(mes)
             await anyio.sleep(0.01)
 
+    async def _cleanup_connection(self) -> None:
+        await self._klippy.on_disconnected()
+        if self._scheduler.get_job("ws_reschedule"):
+            self._scheduler.remove_job("ws_reschedule")
+
     async def run_forever_async(self) -> None:
         if self._log_parser:
             await self.parselog()
 
-        # Todo: use headers instead of inline token
-        async for websocket in connect(
-            uri=f"{self._protocol}://{self._host}:{self._port}/websocket{await self._klippy.get_one_shot_token()}",
-            process_exception=self.on_error,
-            open_timeout=5.0,
-            ping_interval=10.0,  # as moonraker
-            ping_timeout=30.0,  # as moonraker
-            close_timeout=5.0,
-            max_queue=1024,
-            logger=logger,
-            ssl=self._ssl_context,
-        ):
+        delays = backoff()
+        was_connected = False
+
+        while True:
             try:
-                self._ws = websocket
-                self._scheduler.add_job(self.reschedule, "interval", seconds=2, id="ws_reschedule", replace_existing=True, coalesce=True, misfire_grace_time=10)
-                # async for message in self._ws:
-                #     await self.websocket_to_message(message)
+                async with connect(
+                    uri=f"{self._protocol}://{self._host}:{self._port}/websocket",
+                    additional_headers=self._klippy.auth_headers,
+                    open_timeout=5.0,
+                    ping_interval=10.0,  # as moonraker
+                    ping_timeout=30.0,  # as moonraker
+                    close_timeout=5.0,
+                    max_queue=1024,
+                    logger=logger,
+                    ssl=self._ssl_context,
+                ) as websocket:
+                    delays = backoff()
+                    if was_connected:
+                        logger.info("Moonraker reconnected")
+                        self._notifier.send_printer_status_notification("Moonraker reconnected")
+                    was_connected = True
+                    self._ws = websocket
+                    self._scheduler.add_job(self.reschedule, "interval", seconds=2, id="ws_reschedule", replace_existing=True, coalesce=True, misfire_grace_time=10)
 
-                while True:
-                    res = await self._ws.recv(decode=False)
-                    await self.websocket_to_message(res)
+                    while True:
+                        res = await self._ws.recv(decode=False)
+                        await self.websocket_to_message(res)
 
-            except Exception:
-                # Todo: add some TG notification?
-                logger.exception("Failed to reschedule or process websocket")
-                await self._klippy.on_disconnected()
-                if self._scheduler.get_job("ws_reschedule"):
-                    self._scheduler.remove_job("ws_reschedule")
+            except ConnectionClosedOK:
+                logger.warning("Moonraker disconnected, reconnecting")
+                await self._cleanup_connection()
+
+            except ConnectionClosedError as exc:
+                logger.warning("WebSocket connection closed with error: %s", exc)
+                await self._cleanup_connection()
+
+            except Exception as exc:
+                if not self._is_retryable(exc):
+                    logger.exception("Fatal WebSocket error")
+                    self._notifier.send_error(f"Fatal WebSocket error: {exc}")
+                    await self._cleanup_connection()
+                    raise
+
+                delay = next(delays)
+                logger.info("Connect failed; reconnecting in %.1f seconds: %s", delay, traceback.format_exception_only(type(exc), exc)[0].strip())
+                await self._cleanup_connection()
+                await asyncio.sleep(delay)
+
+            await self._klippy.ensure_auth()

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -163,13 +163,13 @@ class WebSocketHelper:
                 await self._klippy.set_printing_filename(print_stats["filename"])
                 self._klippy.printing_duration = print_stats["print_duration"]
                 self._klippy.filament_used = print_stats["filament_used"]
-                # Todo: maybe get print start time and set start interval for job?
+                # TODO: maybe get print start time and set start interval for job?
                 self._notifier.add_notifier_timer()
                 if not self._timelapse.manual_mode:
                     self._timelapse.is_running = True
-                    # TOdo: manual timelapse start check?
+                    # TODO: manual timelapse start check?
 
-            # Fixme: some logic error with states for klippy.paused and printing
+            # TODO: [fixme] some logic error with states for klippy.paused and printing
             if print_stats["state"] == "printing":
                 self._klippy.paused = False
                 if not self._timelapse.manual_mode:
@@ -277,7 +277,7 @@ class WebSocketHelper:
     async def parse_print_stats(self, message_params: list[dict[str, Any]]) -> None:
         state = ""
         print_stats_loc = message_params[0]["print_stats"]
-        # Fixme:  maybe do not parse without state? history data may not be available
+        # TODO: [fixme]  maybe do not parse without state? history data may not be available
         # Message with filename will be sent before printing is started
         if "filename" in print_stats_loc:
             await self._klippy.set_printing_filename(print_stats_loc["filename"])
@@ -285,7 +285,7 @@ class WebSocketHelper:
             self._klippy.filament_used = print_stats_loc["filament_used"]
         if "state" in print_stats_loc:
             state = print_stats_loc["state"]
-        # Fixme: reset notify percent & height on finish/cancel/start
+        # TODO: [fixme] reset notify percent & height on finish/cancel/start
         if "print_duration" in print_stats_loc:
             self._klippy.printing_duration = print_stats_loc["print_duration"]
         if state == "printing":
@@ -307,14 +307,14 @@ class WebSocketHelper:
             self._klippy.paused = True
             if not self._timelapse.manual_mode:
                 self._timelapse.paused = True
-        # Todo: cleanup timelapse dir on cancel print!
+        # TODO: cleanup timelapse dir on cancel print!
         elif state == "complete":
             self._klippy.printing = False
             self._notifier.remove_notifier_timer()
             if not self._timelapse.manual_mode:
                 self._timelapse.is_running = False
                 self._timelapse.send_timelapse()
-            # Fixme: add finish printing method in notifier
+            # TODO: [fixme] add finish printing method in notifier
             self._notifier.send_print_finish()
         elif state == "error":
             self._notifier.update_status_on_abort(state=PrintState.ERROR)
@@ -329,7 +329,7 @@ class WebSocketHelper:
         elif state == "standby":
             self._klippy.printing = False
             self._notifier.remove_notifier_timer()
-            # Fixme: check manual mode
+            # TODO: [fixme] check manual mode
             self._timelapse.is_running = False
             # if not self._timelapse.manual_mode:
             # self._timelapse.send_timelapse()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ select = [
     "SLF",   # flake8-self
     "T20",   # flake8-print
     "TCH",   # flake8-type-checking
+    "TD",    # flake8-todos
     "TID",   # flake8-tidy-imports
     "TRY",   # tryceratops
     "UP",    # pyupgrade
@@ -123,7 +124,8 @@ ignore = [
     "PLR0913", # too-many-arguments
     "PLR0915", # too-many-statements
     "SIM108",  # ternary — would produce very long lines
-    "TD",      # flake8-todos
+    "TD002",   # missing-todo-author
+    "TD003",   # missing-todo-link
     "TRY003",  # long exception messages — not worth extracting
 ]
 [tool.ruff.lint.isort]


### PR DESCRIPTION
The bot authenticates its WebSocket connection using a one-shot token - a single-use token fetched from Moonraker's HTTP API and appended to the WebSocket URL as `?token=<value>`.

## The problem

`websockets.connect()` captures the URL once and reuses it for all automatic reconnection attempts. Since one-shot tokens expire after first use, every reconnection attempt uses an expired token. This causes `Unauthorized` errors on all subsequent JSON-RPC requests:

```
Error response for printer.info: {'code': -32602, 'message': 'Unauthorized'}
Error response for machine.device_power.devices: {'code': -32602, 'message': 'Unauthorized'}
```

For example, this happens when Moonraker restarts while telegram bot is running. It only recovers after restart.

## Fix

- Pass auth headers (`X-Api-Key` or `Authorization: Bearer`) directly via the `additional_headers` parameter instead of one-shot tokens in the URL.
- Use a manual reconnect loop so headers are refreshed on each attempt (needed for JWT auth where tokens expire).
- This also removes the one-shot token from the URL, preventing it from leaking into logs.

## Other changes

- Handle `ConnectionClosedOK` (server shutdown) at warning level instead of error with full traceback
- Send Telegram notification on successful reconnect and on fatal WebSocket errors
- Normalize `Todo`/`Fixme` → `TODO`/`TODO: [fixme]`, enable TD ruff rules