### PR TITLE
Use hostname from Moonraker in greeting message

### DIFF
--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -140,6 +140,7 @@ class Klippy:
         self.paused: bool = False
         self.state: str = ""
         self.state_message: str = ""
+        self.hostname: str = ""
 
         self.printing_duration: float = 0.0
         self.printing_progress: float = 0.0
@@ -388,6 +389,7 @@ class Klippy:
                 connected = response.is_success
 
                 if connected:
+                    self.hostname = orjson.loads(response.text)["result"].get("hostname", "")
                     return ""
                 # TODO: get reason from error handler
                 last_reason = f"{response.status_code}"

--- a/bot/main.py
+++ b/bot/main.py
@@ -1245,7 +1245,8 @@ async def greeting_message(bot: telegram.Bot) -> None:
         if response:
             mess += f"Bot online, no moonraker connection!\n {response} \nFailing..."
         else:
-            mess += "Printer online on " + get_local_ip()
+            name = klippy.hostname or "Printer"
+            mess += f"{name} online on " + get_local_ip()
             if config_wrap.configuration_errors:
                 mess += await klippy.get_versions_info(bot_only=True) + config_wrap.configuration_errors
 


### PR DESCRIPTION
My take on #302. No config changes needed.

This uses system hostname. Klipper calls `socket.gethostname()` on startup to get it. Then through Moonraker it ends up in `/printer/info` response.

Fixes #301 