### PR TITLE
Persist timelapse state, remove dead code, clean up

### DIFF
--- a/bot/camera.py
+++ b/bot/camera.py
@@ -463,7 +463,6 @@ class Camera:
         # never add self in params there!
         if self._save_lapse_photos_as_images:
             with self.take_photo(raw_frame_rgb) as photo:
-                # TODO: [fixme] jpeg_low is bad file extension!
                 filename = self.lapse_dir / f"{time.time()}.{self._img_extension}"
                 with filename.open("wb") as outfile:
                     outfile.write(photo.getvalue())

--- a/bot/camera.py
+++ b/bot/camera.py
@@ -255,7 +255,6 @@ class Camera:
         img.save(bio, "JPEG", quality=100, optimize=True)
         bio.seek(0)
         img.close()
-        img = None  # type: ignore[assignment]
         del img
         return bio
 
@@ -591,7 +590,6 @@ class Camera:
         res_thumb_bytes = thumb_bio.getvalue()
 
         thumb_bio.close()
-        thumb_bio = None  # type: ignore[assignment]
         del thumb_bio
 
         return video_bytes, res_thumb_bytes, width, height, str(video_filepath), gcode_name

--- a/bot/camera.py
+++ b/bot/camera.py
@@ -98,7 +98,6 @@ class Camera:
         self._flip_horizontally: bool = config.camera.flip_horizontally
         self._fourcc: str = config.camera.fourcc
         self._video_duration: int = config.camera.video_duration
-        self._video_buffer_size: int = config.camera.video_buffer_size
         self._stream_fps: int = config.camera.stream_fps
         self._klippy: Klippy = klippy
 

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -364,8 +364,10 @@ class TimelapseConfig(ConfigHelper):
         self.interval: int = self._get_int("time", default=0, min_value=0)
         self.target_fps: int = self._get_int("target_fps", default=15, above=0)
         self.limit_fps: bool = self._get_boolean("limit_fps", default=False)
-        self.min_lapse_duration: int = self._get_int("min_lapse_duration", default=0, min_value=0)  # TODO: check if max_value is max_lapse_duration
-        self.max_lapse_duration: int = self._get_int("max_lapse_duration", default=0, min_value=0)  # TODO: check if min_value is more than min_lapse_duration
+        self.min_lapse_duration: int = self._get_int("min_lapse_duration", default=0, min_value=0)
+        self.max_lapse_duration: int = self._get_int("max_lapse_duration", default=0, min_value=0)
+        if self.min_lapse_duration and self.max_lapse_duration and self.min_lapse_duration > self.max_lapse_duration:
+            self._parsing_errors.append(f"min_lapse_duration ({self.min_lapse_duration}) is greater than max_lapse_duration ({self.max_lapse_duration})")
         self.last_frame_duration: int = self._get_int("last_frame_duration", default=5, min_value=0)
         self.after_lapse_gcode: str = self._get_str("after_lapse_gcode", default="")
         self.send_finished_lapse: bool = self._get_boolean("send_finished_lapse", default=True)

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -270,7 +270,6 @@ class CameraConfig(ConfigHelper):
         "rotate",
         "fourcc",
         "video_duration",
-        "video_buffer_size",
         "fps",
         "light_control_timeout",
         "picture_quality",
@@ -294,7 +293,6 @@ class CameraConfig(ConfigHelper):
         self.threads: int = self._get_int("threads", default=2, min_value=0)
 
         self.video_duration: int = self._get_int("video_duration", default=5, above=0)
-        self.video_buffer_size: int = self._get_int("video_buffer_size", default=2, above=0)
         self.light_timeout: int = self._get_int("light_control_timeout", default=0, min_value=0)
         self.picture_quality: str = self._get_str("picture_quality", default="high", allowed_values=["low", "high"])
 

--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -251,10 +251,6 @@ class Klippy:
         return self._get_full_macro_list()
 
     @property
-    def moonraker_host(self) -> str:
-        return self._host
-
-    @property
     def auth_headers(self) -> dict[str, str]:
         if self._jwt_token:
             return {"Authorization": f"Bearer {self._jwt_token}"}
@@ -470,9 +466,6 @@ class Klippy:
                 else:
                     message += self._device_message(name, value)
         return message
-
-    async def execute_command(self, *command: str) -> None:
-        await self.make_request("POST", "/api/printer/command", json={"commands": [f"{el}" for el in command]})
 
     async def execute_gcode_script(self, gcode: str) -> None:
         await self.make_request("GET", f"/printer/gcode/script?script={gcode}")

--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -320,7 +320,7 @@ class Klippy:
             if "filename" not in resp:
                 logger.error('"filename" field is not present in response: %s', resp)
             if "thumbnails" not in resp:
-                logger.error('"thumbnails" field is not present in response: %s', resp)
+                logger.info("No thumbnails in file metadata for %s", resp.get("filename", "unknown"))
 
     @property
     def printing_filename_with_time(self) -> str:
@@ -486,7 +486,7 @@ class Klippy:
     async def _populate_with_thumb(self, thumb_path: str, message: str) -> tuple[str, BytesIO]:
         if not thumb_path:
             img = Image.open("../imgs/nopreview.png").convert("RGB")
-            logger.warning("Empty thumbnail_path")
+            logger.debug("Empty thumbnail_path")
         else:
             response = await self.make_request("GET", f"/server/files/gcodes/{urllib.parse.quote(thumb_path)}")
             try:

--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -294,7 +294,6 @@ class Klippy:
     async def set_printing_filename(self, new_value: str) -> None:
         if new_value == self._printing_filename:
             logger.info("'filename' has the same value as the current: %s", new_value)
-            # TODO: [fixme] maybe we should reset file info on all filename updates?
             self._reset_file_info()
             return
 

--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -363,17 +363,21 @@ class Klippy:
         except httpx.HTTPError:
             logger.exception("Failed to refresh token")
 
-    async def make_request(self, method: str, url_path: str, json: Any = None, files: Any = None, timeout: int = 30) -> httpx.Response:
-        res = await self._client.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=self.auth_headers, files=files, timeout=timeout)
+    async def make_request(self, method: str, url_path: str, json: Any = None, files: Any = None, timeout: int = 30, *, log_errors: bool = True) -> httpx.Response:
+        headers = {**self.auth_headers, "Content-Type": "application/json"} if json else self.auth_headers
+        content = orjson.dumps(json) if json else None
+        res = await self._client.request(method, f"{self._host}{url_path}", content=content, headers=headers, files=files, timeout=timeout)
         if res.status_code == httpx.codes.UNAUTHORIZED:
             logger.debug("JWT token expired, refreshing...")
             await self._refresh_moonraker_token()
-            res = await self._client.request(method, f"{self._host}{url_path}", content=orjson.dumps(json) if json else None, headers=self.auth_headers, files=files, timeout=timeout)
+            headers = {**self.auth_headers, "Content-Type": "application/json"} if json else self.auth_headers
+            res = await self._client.request(method, f"{self._host}{url_path}", content=content, headers=headers, files=files, timeout=timeout)
 
-        try:
-            res.raise_for_status()
-        except httpx.HTTPError:
-            logger.exception("Failed to make request asynchronously")
+        if log_errors:
+            try:
+                res.raise_for_status()
+            except httpx.HTTPError:
+                logger.exception("Failed to make request asynchronously")
 
         return res
 
@@ -668,23 +672,21 @@ class Klippy:
 
     # moonraker database section
     async def get_param_from_db(self, param_name: str) -> Any:
-        res = await self.make_request("GET", f"/server/database/item?namespace={self._dbname}&key={param_name}")
+        res = await self.make_request("GET", f"/server/database/item?namespace={self._dbname}&key={param_name}", log_errors=False)
         if res.is_success:
             return orjson.loads(res.text)["result"]["value"]
-        logger.error("Failed getting %s from %s \n\n%s", param_name, self._dbname, res)
-        # TODO: [fixme] return default value? check for 404!
+        if res.status_code == httpx.codes.NOT_FOUND:
+            return None
+        logger.error("Failed getting %s from database: %s", param_name, res.status_code)
         return None
 
     async def save_param_to_db(self, param_name: str, value: Any) -> None:
-        data = {"namespace": self._dbname, "key": param_name, "value": value}
-        res = await self.make_request("POST", "/server/database/item", json=data)
-        if not res.is_success:
-            logger.error("Failed saving %s to %s \n\n%s", param_name, self._dbname, res)
+        await self.make_request("POST", f"/server/database/item?namespace={self._dbname}&key={param_name}", json={"value": value})
 
     async def delete_param_from_db(self, param_name: str) -> None:
-        res = await self.make_request("DELETE", f"/server/database/item?namespace={self._dbname}&key={param_name}")
-        if not res.is_success:
-            logger.error("Failed getting %s from %s \n\n%s", param_name, self._dbname, res)
+        res = await self.make_request("DELETE", f"/server/database/item?namespace={self._dbname}&key={param_name}", log_errors=False)
+        if not res.is_success and res.status_code != httpx.codes.NOT_FOUND:
+            logger.error("Failed deleting %s from database: %s", param_name, res.status_code)
 
     # macro data section
     async def save_data_to_macro(self, lapse_size: int, filename: str, path: str) -> None:

--- a/bot/main.py
+++ b/bot/main.py
@@ -658,7 +658,6 @@ async def button_lapse_handler(update: Update, context: ContextTypes.DEFAULT_TYP
     )
     await context.bot.send_chat_action(chat_id=config_wrap.secrets.chat_id, action=ChatAction.RECORD_VIDEO)
     await timelapse.upload_timelapse(lapse_name, info_mess)
-    info_mess = None  # type: ignore[assignment]
     await query.delete_message()
     await check_unfinished_lapses(context.bot)
 

--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -465,7 +465,6 @@ class Notifier:
                 max_instances=1,
                 replace_existing=True,
             )
-        # TODO: reset something? or check if reset by setting new filename?
 
     async def _send_print_finish(self) -> None:
         self._schedule_notification(state=PrintState.FINISH)

--- a/bot/timelapse.py
+++ b/bot/timelapse.py
@@ -6,7 +6,7 @@ import asyncio
 from concurrent.futures import Future, ThreadPoolExecutor
 import gc
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 from telegram import InputFile
 from telegram.constants import ChatAction
@@ -30,6 +30,12 @@ def logging_callback(future: Future[Any]) -> None:
         return
 
     logger.error(exc, exc_info=(type(exc), exc, exc.__traceback__))
+
+
+_DB_KEY: Final = "timelapse_state"
+_STATE_RUNNING: Final = "running"
+_STATE_PAUSED: Final = "paused"
+_STATE_LAST_HEIGHT: Final = "last_height"
 
 
 class Timelapse:
@@ -181,6 +187,7 @@ class Timelapse:
             self._camera.lapse_missed_frames = 0
         else:
             self._remove_timelapse_timer()
+        self._schedule_save()
 
     @property
     def paused(self) -> bool:
@@ -193,6 +200,7 @@ class Timelapse:
             self._remove_timelapse_timer()
         elif self._running:
             self._add_timelapse_timer()
+        self._schedule_save()
 
     def take_lapse_photo(self, position_z: float | None = None, manually: bool = False, gcode: bool = False) -> None:
         if not self._enabled:
@@ -218,6 +226,7 @@ class Timelapse:
         elif self._height > 0.0 and (position_z >= self._last_height + self._height or 0.0 < position_z < self._last_height - self._height):
             self._executors_pool.submit(self._camera.take_lapse_photo, gcode=gcode_command).add_done_callback(logging_callback)
             self._last_height = position_z
+            self._schedule_save()
 
     def clean(self) -> None:
         self._camera.clean()
@@ -341,6 +350,39 @@ class Timelapse:
         self._paused = False
         self._last_height = 0.0
         self._camera.lapse_missed_frames = 0
+        self._schedule_save()
+
+    def _schedule_save(self) -> None:
+        """Schedule state save without blocking the event loop."""
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(self._save_state())  # noqa: RUF006
+        except RuntimeError:
+            pass
+
+    async def _save_state(self) -> None:
+        """Persist timelapse state to Moonraker database."""
+        if not self._running:
+            await self._clear_state()
+            return
+        state = {_STATE_RUNNING: self._running, _STATE_PAUSED: self._paused, _STATE_LAST_HEIGHT: self._last_height}
+        await self._klippy.save_param_to_db(_DB_KEY, state)
+
+    async def _clear_state(self) -> None:
+        await self._klippy.delete_param_from_db(_DB_KEY)
+
+    async def restore_state(self) -> None:
+        """Restore timelapse state from database after reconnect."""
+        state = await self._klippy.get_param_from_db(_DB_KEY)
+        if state is None:
+            return
+        self._running = state.get(_STATE_RUNNING, False)
+        self._paused = state.get(_STATE_PAUSED, False)
+        self._last_height = state.get(_STATE_LAST_HEIGHT, 0.0)
+        if self._running:
+            logger.info("Restored timelapse state: running=%s, paused=%s, last_height=%.2f", self._running, self._paused, self._last_height)
+            if not self._paused:
+                self._add_timelapse_timer()
 
     async def parse_timelapse_params(self, message: str) -> None:
         mass_parts = message.split(sep=" ")

--- a/bot/timelapse.py
+++ b/bot/timelapse.py
@@ -180,6 +180,8 @@ class Timelapse:
 
     @is_running.setter
     def is_running(self, new_val: bool) -> None:
+        if new_val != self._running:
+            logger.debug("Timelapse is_running: %s -> %s", self._running, new_val)
         self._running = new_val
         self._paused = False
         if new_val:
@@ -222,11 +224,15 @@ class Timelapse:
         gcode_command = self._after_photo_gcode if gcode and self._after_photo_gcode else ""
 
         if position_z is None:
+            logger.debug("Taking lapse photo (no position)")
             self._executors_pool.submit(self._camera.take_lapse_photo, gcode=gcode_command).add_done_callback(logging_callback)
         elif self._height > 0.0 and (position_z >= self._last_height + self._height or 0.0 < position_z < self._last_height - self._height):
+            logger.debug("Taking lapse photo at Z=%.2f (last=%.2f, threshold=%.2f)", position_z, self._last_height, self._height)
             self._executors_pool.submit(self._camera.take_lapse_photo, gcode=gcode_command).add_done_callback(logging_callback)
             self._last_height = position_z
             self._schedule_save()
+        else:
+            logger.debug("Skipping lapse photo at Z=%.2f (last=%.2f, threshold=%.2f)", position_z, self._last_height, self._height)
 
     def clean(self) -> None:
         self._camera.clean()
@@ -291,6 +297,7 @@ class Timelapse:
                     self._camera.cleanup(lapse_filename)
             else:
                 await info_mess.edit_text(text="Time-lapse creation finished")
+            logger.info("Timelapse assembly complete for %s", gcode_name)
 
             video_bio_nbytes = len(video_bytes)
 
@@ -315,6 +322,7 @@ class Timelapse:
 
         lapse_filename = self._klippy.printing_filename_with_time
         gcode_name = self._klippy.printing_filename
+        logger.info("Starting timelapse assembly for %s", gcode_name)
 
         info_mess: Message = await self._bot.send_message(
             chat_id=self._chat_id,

--- a/bot/timelapse.py
+++ b/bot/timelapse.py
@@ -300,11 +300,7 @@ class Timelapse:
             logger.info("Timelapse assembly complete for %s", gcode_name)
 
             video_bio_nbytes = len(video_bytes)
-
-            thumb_bytes = None  # type: ignore[assignment]
-            video_bytes = None  # type: ignore[assignment]
             del video_bytes, thumb_bytes
-
             gc.collect()
 
             if self._after_lapse_gcode and gcode_name_out is not None:
@@ -341,7 +337,6 @@ class Timelapse:
         await self._bot.send_chat_action(chat_id=self._chat_id, action=ChatAction.RECORD_VIDEO)
 
         await self.upload_timelapse(lapse_filename, info_mess, gcode_name)
-        info_mess = None  # type: ignore[assignment]
 
     def send_timelapse(self) -> None:
         self._sched.add_job(

--- a/bot/timelapse.py
+++ b/bot/timelapse.py
@@ -219,9 +219,6 @@ class Timelapse:
             self._executors_pool.submit(self._camera.take_lapse_photo, gcode=gcode_command).add_done_callback(logging_callback)
             self._last_height = position_z
 
-    def take_test_lapse_photo(self) -> None:
-        self._executors_pool.submit(self._camera.take_lapse_photo).add_done_callback(logging_callback)
-
     def clean(self) -> None:
         self._camera.clean()
 

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-from functools import wraps
 from http import HTTPStatus
 import logging
 import os
 import ssl
 import traceback
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any
 
 import aiofiles
 import anyio
@@ -50,20 +49,6 @@ _RETRYABLE_HTTP_CODES = frozenset(
 )
 
 logger = logging.getLogger(__name__)
-
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-
-def websocket_alive(func: F) -> F:
-    @wraps(func)
-    def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
-        if self.websocket is None:
-            logger.warning("Websocket call `%s` on non initialized ws", func.__name__)
-            return None
-        return func(self, *args, **kwargs)
-
-    return wrapper  # type: ignore[return-value]
 
 
 class WebSocketHelper:

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -154,7 +154,6 @@ class WebSocketHelper:
                 self._notifier.add_notifier_timer()
                 if not self._timelapse.manual_mode:
                     self._timelapse.is_running = True
-                    # TODO: manual timelapse start check?
                     self._timelapse.paused = state == "paused"
         if "display_status" in status_resp:
             self._notifier.m117_status = status_resp["display_status"]["message"]
@@ -352,6 +351,7 @@ class WebSocketHelper:
                     if klippy_state == "ready":
                         if self._ws.state is State.OPEN:
                             await self._klippy.on_connected()
+                            await self._timelapse.restore_state()
                             if self._klippy.state_message:
                                 self._notifier.send_error(f"Klippy changed state to {self._klippy.state}")
                                 self._klippy.state_message = ""

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -143,8 +143,10 @@ class WebSocketHelper:
     async def status_response(self, status_resp: dict[str, Any]) -> None:
         if "print_stats" in status_resp:
             print_stats = status_resp["print_stats"]
-            if print_stats["state"] in ["printing", "paused"]:
+            state = print_stats["state"]
+            if state in ["printing", "paused"]:
                 self._klippy.printing = True
+                self._klippy.paused = state == "paused"
                 await self._klippy.set_printing_filename(print_stats["filename"])
                 self._klippy.printing_duration = print_stats["print_duration"]
                 self._klippy.filament_used = print_stats["filament_used"]
@@ -153,16 +155,7 @@ class WebSocketHelper:
                 if not self._timelapse.manual_mode:
                     self._timelapse.is_running = True
                     # TODO: manual timelapse start check?
-
-            # TODO: [fixme] some logic error with states for klippy.paused and printing
-            if print_stats["state"] == "printing":
-                self._klippy.paused = False
-                if not self._timelapse.manual_mode:
-                    self._timelapse.paused = False
-            if print_stats["state"] == "paused":
-                self._klippy.paused = True
-                if not self._timelapse.manual_mode:
-                    self._timelapse.paused = True
+                    self._timelapse.paused = state == "paused"
         if "display_status" in status_resp:
             self._notifier.m117_status = status_resp["display_status"]["message"]
             self._klippy.printing_progress = status_resp["display_status"]["progress"]

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -285,7 +285,6 @@ class WebSocketHelper:
             self._klippy.filament_used = print_stats_loc["filament_used"]
         if "state" in print_stats_loc:
             state = print_stats_loc["state"]
-        # TODO: [fixme] reset notify percent & height on finish/cancel/start
         if "print_duration" in print_stats_loc:
             self._klippy.printing_duration = print_stats_loc["print_duration"]
         if state == "printing":
@@ -314,7 +313,6 @@ class WebSocketHelper:
             if not self._timelapse.manual_mode:
                 self._timelapse.is_running = False
                 self._timelapse.send_timelapse()
-            # TODO: [fixme] add finish printing method in notifier
             self._notifier.send_print_finish()
         elif state == "error":
             self._notifier.update_status_on_abort(state=PrintState.ERROR)

--- a/tests/camera_test.py
+++ b/tests/camera_test.py
@@ -15,7 +15,6 @@ def make_camera(test_dir: Path) -> Camera:
 
     config.camera.fourcc = "h264"
     config.camera.video_duration = 5
-    config.camera.video_buffer_size = 10
     config.camera.stream_fps = 15
 
     config.timelapse.base_dir = test_dir

--- a/tests/resources/telegram.conf
+++ b/tests/resources/telegram.conf
@@ -18,7 +18,6 @@ rotate: 90_cw
 fourcc: h264
 fps: 30
 video_duration: 15
-video_buffer_size: 5
 light_control_timeout: 2
 picture_quality: high
 

--- a/tests/resources/telegram_secrets.conf
+++ b/tests/resources/telegram_secrets.conf
@@ -20,7 +20,6 @@ rotate: 90_cw
 fourcc: h264
 fps: 30
 video_duration: 15
-video_buffer_size: 5
 light_control_timeout: 2
 picture_quality: high
 

--- a/tests/timelapse_test.py
+++ b/tests/timelapse_test.py
@@ -1,0 +1,107 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from timelapse import Timelapse
+
+
+@pytest.fixture
+def mock_timelapse() -> Timelapse:
+    config = MagicMock()
+    config.timelapse.enabled = True
+    config.timelapse.mode_manual = True
+    config.timelapse.height = 0.0
+    config.timelapse.interval = 0
+    config.timelapse.target_fps = 15
+    config.timelapse.limit_fps = False
+    config.timelapse.min_lapse_duration = 0
+    config.timelapse.max_lapse_duration = 0
+    config.timelapse.last_frame_duration = 5
+    config.timelapse.after_lapse_gcode = ""
+    config.timelapse.send_finished_lapse = True
+    config.timelapse.after_photo_gcode = ""
+    config.bot_config.debug = False
+    config.bot_config.max_upload_file_size = 50
+    config.secrets.chat_id = 123
+    config.telegram_ui.silent_progress = False
+
+    klippy = MagicMock()
+    klippy.save_param_to_db = AsyncMock()
+    klippy.get_param_from_db = AsyncMock(return_value=None)
+    klippy.delete_param_from_db = AsyncMock()
+
+    camera = MagicMock()
+    camera.enabled = True
+
+    scheduler = MagicMock()
+    scheduler.get_job.return_value = None
+
+    bot = MagicMock()
+
+    return Timelapse(config, klippy, camera, scheduler, bot, MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_save_and_restore_state(mock_timelapse: Timelapse) -> None:
+    saved_state: dict[str, object] = {}
+
+    async def mock_save(key: str, value: object) -> None:
+        saved_state[key] = value
+
+    async def mock_get(key: str) -> object:
+        return saved_state.get(key)
+
+    mock_timelapse._klippy.save_param_to_db = AsyncMock(side_effect=mock_save)
+    mock_timelapse._klippy.get_param_from_db = AsyncMock(side_effect=mock_get)
+
+    mock_timelapse._running = True
+    mock_timelapse._paused = True
+    mock_timelapse._last_height = 12.5
+    await mock_timelapse._save_state()
+
+    mock_timelapse._running = False
+    mock_timelapse._paused = False
+    mock_timelapse._last_height = 0.0
+    await mock_timelapse.restore_state()
+
+    assert mock_timelapse._running is True
+    assert mock_timelapse._paused is True
+    assert mock_timelapse._last_height == 12.5
+
+
+@pytest.mark.asyncio
+async def test_stop_all_clears_state(mock_timelapse: Timelapse) -> None:
+    mock_timelapse._running = True
+    mock_timelapse.stop_all()
+
+    assert mock_timelapse._running is False
+    assert mock_timelapse._paused is False
+    assert mock_timelapse._last_height == 0.0
+
+
+@pytest.mark.asyncio
+async def test_restore_with_no_saved_state(mock_timelapse: Timelapse) -> None:
+    mock_timelapse._klippy.get_param_from_db = AsyncMock(return_value=None)
+
+    mock_timelapse._running = False
+    mock_timelapse._paused = False
+    mock_timelapse._last_height = 0.0
+    await mock_timelapse.restore_state()
+
+    assert mock_timelapse._running is False
+    assert mock_timelapse._paused is False
+    assert mock_timelapse._last_height == 0.0
+
+
+@pytest.mark.asyncio
+async def test_save_clears_on_not_running(mock_timelapse: Timelapse) -> None:
+    delete_mock = AsyncMock()
+    save_mock = AsyncMock()
+    mock_timelapse._klippy.delete_param_from_db = delete_mock
+    mock_timelapse._klippy.save_param_to_db = save_mock
+
+    mock_timelapse._running = False
+    await mock_timelapse._save_state()
+
+    delete_mock.assert_called_once_with("timelapse_state")
+    save_mock.assert_not_called()


### PR DESCRIPTION
## Timelapse state persistence

Save timelapse state (`running`, `paused`, `last_height`) to Moonraker's database on every state change. On reconnect, state is restored so manual timelapses resume after bot restart and auto-mode timelapses
continue from the correct Z height.

Tested locally with auto-mode (height-based) and manual-mode (timer-based) timelapses. Restarted bot mid-print in both cases — state restored correctly, frames resumed without duplicates, video assembled with frames from before and after restart.

## Database method fixes

- `make_request` now sends `Content-Type: application/json` when body is present
- Handle 404 silently in `get_param_from_db` / `delete_param_from_db` (expected for missing keys)
- `save_param_to_db` sends namespace/key as query params (Moonraker API requirement)
- Fix copy-paste error in `delete_param_from_db` error message

## Dead code removed

- `moonraker_host` property — caller removed in 2022 camera refactor
- `execute_command` method — old Klipper API (`/api/printer/command`), replaced by `execute_gcode_script`
- `take_test_lapse_photo` method — never wired to a command handler
- `websocket_alive` decorator — left behind after asyncio migration
- `video_buffer_size` config option and attribute — queue-based video capture was replaced by list-based approach, config value was silently ignored
- Redundant `None` assignments before `del`

## Other changes

- Remove stale fixme comments
- Simplify `status_response` state logic
- Validate `min_lapse_duration` does not exceed `max_lapse_duration`
- Downgrade missing thumbnails log from error to info/debug
- Add debug logging for timelapse frame capture, info for assembly start/complete