### PR TITLE
Display humidity from sensors

### DIFF
--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -105,7 +105,7 @@ class Klippy:
 
     _DATA_MACRO: Final = "bot_data"
 
-    _SENSOR_PARAMS: Final = ["temperature", "target", "power", "speed", "rpm"]
+    _SENSOR_PARAMS: Final = ["temperature", "humidity", "target", "power", "speed", "rpm"]
 
     _POWER_DEVICE_PARAMS: Final = ["device", "status", "locked_while_printing", "type", "is_shutdown"]
     _MAX_CONNECT_RETRIES: Final = 10
@@ -441,6 +441,8 @@ class Klippy:
             message += f" {round(value['speed'] * 100)}%"
         if "rpm" in value and value["rpm"] is not None:
             message += f" {round(value['rpm'])} RPM"
+        if "humidity" in value:
+            message += emoji.emojize(" :droplet: ", language="alias") + f"{round(value['humidity'])}%"
 
         return message
 

--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -419,7 +419,7 @@ class Klippy:
     @staticmethod
     def _sensor_message(name: str, value: dict[str, Any]) -> str:
         temp_display_threshold: Final = 2
-        sens_name = re.sub(r"([A-Z]|\d|_)", r" \1", name).replace("_", "")
+        display_name = re.sub(r"([a-z])([A-Z])", r"\1 \2", name).replace("_", " ")
         message = ""
 
         if "power" in value:
@@ -429,7 +429,7 @@ class Klippy:
         elif "temperature" in value:
             message = emoji.emojize(":thermometer: ", language="alias")
 
-        message += f"{sens_name.title()}:"
+        message += f"{display_name.title()}:"
 
         if "temperature" in value:
             message += f" {round(value['temperature'])} \N{DEGREE SIGN}C"

--- a/tests/klippy_test.py
+++ b/tests/klippy_test.py
@@ -12,6 +12,7 @@ test_sensors = {
     "heater": {"temperature": 155.345325234, "target": 255.343434, "power": 0.60},
     "temp": {"temperature": 155.345325234},
     "fan": {"temperature": 155.345325234, "target": 255.343434, "speed": 0.75, "rpm": 2550.255},
+    "sht3x": {"temperature": 24.7, "humidity": 45.3},
 }
 
 
@@ -22,6 +23,9 @@ def test_sensor_message() -> None:
     assert heater_message == "♨️ Heater: 155 °C ➡️ 255 °C 🔥"
     assert fan_message == "🌪️ Fan: 155 °C ➡️ 255 °C 75% 2550 RPM"
     assert temp_sensor_message == "🌡️ Temp: 155 °C"
+
+    sht3x_message = Klippy._sensor_message("sht3x", test_sensors["sht3x"])
+    assert sht3x_message == "🌡️ Sht 3X: 25 °C 💧 45%"
 
 
 @pytest.fixture

--- a/tests/klippy_test.py
+++ b/tests/klippy_test.py
@@ -25,7 +25,17 @@ def test_sensor_message() -> None:
     assert temp_sensor_message == "🌡️ Temp: 155 °C"
 
     sht3x_message = Klippy._sensor_message("sht3x", test_sensors["sht3x"])
-    assert sht3x_message == "🌡️ Sht 3X: 25 °C 💧 45%"
+    assert sht3x_message == "🌡️ Sht3X: 25 °C 💧 45%"
+
+
+def test_sensor_name_formatting() -> None:
+    data: dict[str, Any] = {"temperature": 20.0}
+    assert "Sht3X:" in Klippy._sensor_message("sht3x", data)
+    assert "Sht3X:" in Klippy._sensor_message("SHT3X", data)
+    assert "Bme280:" in Klippy._sensor_message("bme280", data)
+    assert "Heater Bed:" in Klippy._sensor_message("heater_bed", data)
+    assert "Heater Bed:" in Klippy._sensor_message("heaterBed", data)
+    assert "Extruder:" in Klippy._sensor_message("extruder", data)
 
 
 @pytest.fixture


### PR DESCRIPTION
- Subscribe to humidity sensor parameter and display it in status messages with a droplet emoji
- Fix sensor name formatting — the regex that splits camelCase names was too aggressive
with digits and consecutive uppercase letters (`SHT3X` → `S H T 3 X`, `bme280` → `Bme 2 8 0`).
Now only splits on lowercase to uppercase transitions.

Closes #388