### PR TITLE
Add multi-camera support

### DIFF
--- a/bot/camera.py
+++ b/bot/camera.py
@@ -28,7 +28,7 @@ from PIL import Image
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-    from configuration import ConfigWrapper
+    from configuration import CameraConfig, ConfigWrapper
     from klippy import Klippy, PowerDevice
 
 try:
@@ -131,42 +131,42 @@ def create_thumb(image: NDArray[Any]) -> tuple[BytesIO, int, int]:
 class Camera(abc.ABC):
     """Abstract base for all camera backends."""
 
-    def __init__(self, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> None:
-        self.enabled: bool = bool(config.camera.enabled and config.camera.host)
-        self._host: str = config.camera.host
-        self._flip_vertically: bool = config.camera.flip_vertically
-        self._flip_horizontally: bool = config.camera.flip_horizontally
-        self._fourcc: str = config.camera.fourcc
-        self._video_duration: int = config.camera.video_duration
-        self._stream_fps: int = config.camera.stream_fps
+    def __init__(self, cam_config: CameraConfig, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> None:
+        self.name: str = cam_config.name
+        self._host: str = cam_config.host
+        self._flip_vertically: bool = cam_config.flip_vertically
+        self._flip_horizontally: bool = cam_config.flip_horizontally
+        self._fourcc: str = cam_config.fourcc
+        self._video_duration: int = cam_config.video_duration
+        self._stream_fps: int = cam_config.stream_fps
         self._klippy: Klippy = klippy
 
         self._light_need_off: bool = False
         self._light_need_off_lock: threading.Lock = threading.Lock()
 
-        self.light_timeout: int = config.camera.light_timeout
+        self.light_timeout: int = cam_config.light_timeout
         self.light_device: PowerDevice | None = self._klippy.light_device
         self._camera_lock: threading.Lock = threading.Lock()
         self.light_lock = threading.Lock()
         self.light_timer_event: threading.Event = threading.Event()
         self.light_timer_event.set()
 
-        self._picture_quality = config.camera.picture_quality
+        self._picture_quality = cam_config.picture_quality
         self._img_extension: str
-        if config.camera.picture_quality in ["low", "high"]:
+        if cam_config.picture_quality in ["low", "high"]:
             self._img_extension = "jpeg"
         else:
-            self._img_extension = config.camera.picture_quality
+            self._img_extension = cam_config.picture_quality
 
         self._light_requests: int = 0
         self._light_request_lock: threading.Lock = threading.Lock()
 
         self._rotation_count: int | None
-        if config.camera.rotate == "90_cw":
+        if cam_config.rotate == "90_cw":
             self._rotation_count = 1
-        elif config.camera.rotate == "180":
+        elif cam_config.rotate == "180":
             self._rotation_count = 2
-        elif config.camera.rotate == "90_ccw":
+        elif cam_config.rotate == "90_ccw":
             self._rotation_count = 3
         else:
             self._rotation_count = None
@@ -219,8 +219,8 @@ class Camera(abc.ABC):
 class NumpyCamera(Camera):
     """Camera backend using numpy arrays for frame processing. Base for OpenCV and FFmpeg cameras."""
 
-    def __init__(self, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> None:
-        super().__init__(config, klippy, logging_handler)
+    def __init__(self, cam_config: CameraConfig, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> None:
+        super().__init__(cam_config, config, klippy, logging_handler)
         self._save_lapse_photos_as_images: bool = config.timelapse.save_lapse_photos_as_images
 
     @property
@@ -378,15 +378,9 @@ class OpenCVCamera(NumpyCamera):
 
     # TODO: [fixme] deprecated! use T-API https://learnopencv.com/opencv-transparent-api/
 
-    def __init__(self, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> None:
-        super().__init__(config, klippy, logging_handler)
-
-        if not cv2:
-            logger.warning("OpenCV not available, camera disabled")
-            self.enabled = False
-            return
-
-        self._threads: int = config.camera.threads
+    def __init__(self, cam_config: CameraConfig, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> None:
+        super().__init__(cam_config, config, klippy, logging_handler)
+        self._threads: int = cam_config.threads
 
         if config.bot_config.debug:
             logger.debug(cv2.getBuildInformation())
@@ -453,8 +447,8 @@ class OpenCVCamera(NumpyCamera):
 class FFmpegCamera(NumpyCamera):
     """Camera backend using FFmpeg for RTSP/stream capture."""
 
-    def __init__(self, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> None:
-        super().__init__(config, klippy, logging_handler)
+    def __init__(self, cam_config: CameraConfig, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> None:
+        super().__init__(cam_config, config, klippy, logging_handler)
 
         self._cam_timeout: int = 5
         self._videoinfo = get_info(self._host, self._cam_timeout)
@@ -485,11 +479,11 @@ class MjpegCamera(Camera):
         3: Image.Transpose.ROTATE_90,
     }
 
-    def __init__(self, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> None:
-        super().__init__(config, klippy, logging_handler)
+    def __init__(self, cam_config: CameraConfig, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> None:
+        super().__init__(cam_config, config, klippy, logging_handler)
         self._img_extension = "jpeg"
-        self._host = config.camera.host
-        self._host_snapshot = config.camera.host_snapshot or self._host.replace("stream", "snapshot")
+        self._host = cam_config.host
+        self._host_snapshot = cam_config.host_snapshot or self._host.replace("stream", "snapshot")
         self._http = httpx.Client(timeout=5, verify=False)
 
     @property
@@ -608,8 +602,8 @@ class MjpegCamera(Camera):
 class RawStreamCamera(MjpegCamera):
     """Camera backend for direct H.264/snapshot passthrough without re-encoding."""
 
-    def __init__(self, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> None:
-        super().__init__(config, klippy, logging_handler)
+    def __init__(self, cam_config: CameraConfig, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> None:
+        super().__init__(cam_config, config, klippy, logging_handler)
 
         if self._flip_vertically or self._flip_horizontally or self._rotation_count is not None:
             logger.warning("raw_stream camera: flip/rotate not supported for video (stream copy). Use type=ffmpeg if you need video transforms.")
@@ -645,3 +639,19 @@ class RawStreamCamera(MjpegCamera):
             os_nice(0)
 
         return _read_and_cleanup_video(filepath), thumb_bio, width, height
+
+
+def create_camera(cam_config: CameraConfig, config: ConfigWrapper, klippy: Klippy, logging_handler: logging.Handler) -> Camera | None:
+    if not cam_config.enabled or not cam_config.host:
+        return None
+    cam_type = cam_config.cam_type
+    if cam_type == "mjpeg":
+        return MjpegCamera(cam_config, config, klippy, logging_handler)
+    if cam_type == "ffmpeg":
+        return FFmpegCamera(cam_config, config, klippy, logging_handler)
+    if cam_type == "raw_stream":
+        return RawStreamCamera(cam_config, config, klippy, logging_handler)
+    if not cv2:
+        logger.warning("OpenCV not available, camera '%s' disabled", cam_config.name)
+        return None
+    return OpenCVCamera(cam_config, config, klippy, logging_handler)

--- a/bot/camera.py
+++ b/bot/camera.py
@@ -88,13 +88,13 @@ def os_nice(value: int) -> None:
 def _encode_frames(
     frame_list: list[bytes],
     filepath: Path,
-    fourcc: str,
+    video_codec: str,
     duration: float,
     transform: Callable[[Any], NDArray[Any]],
 ) -> None:
     res_fps = len(frame_list) / duration
     logger.debug("res fps - %s", res_fps)
-    out = ffmpegcv.VideoWriter(filepath.as_posix(), codec=fourcc, fps=res_fps)
+    out = ffmpegcv.VideoWriter(filepath.as_posix(), codec=video_codec, fps=res_fps)
     for el in frame_list:
         frame = pickle.loads(el)
         out.write(transform(frame))
@@ -136,7 +136,7 @@ class Camera(abc.ABC):
         self._host: str = cam_config.host
         self._flip_vertically: bool = cam_config.flip_vertically
         self._flip_horizontally: bool = cam_config.flip_horizontally
-        self._fourcc: str = cam_config.fourcc
+        self._video_codec: str = cam_config.video_codec
         self._video_duration: int = cam_config.video_duration
         self._stream_fps: int = cam_config.stream_fps
         self._klippy: Klippy = klippy
@@ -175,6 +175,10 @@ class Camera(abc.ABC):
             logger.addHandler(logging_handler)
         if config.bot_config.debug:
             logger.setLevel(logging.DEBUG)
+
+    @property
+    def video_codec(self) -> str:
+        return self._video_codec
 
     @abc.abstractmethod
     def take_photo(self) -> BytesIO: ...
@@ -341,7 +345,7 @@ class NumpyCamera(Camera):
                 del frame_loc
 
             self._release_capture()
-            _encode_frames(frame_list, filepath, self._fourcc, self._video_duration, self._transform_frame)
+            _encode_frames(frame_list, filepath, self._video_codec, self._video_duration, self._transform_frame)
             os_nice(0)
 
         return _read_and_cleanup_video(filepath), thumb_bio, width, height
@@ -593,7 +597,7 @@ class MjpegCamera(Camera):
                         frame_list.append(pickle.dumps(frame_loc))
                 del frame_loc
 
-            _encode_frames(frame_list, filepath, self._fourcc, self._video_duration, self._image_to_frame)
+            _encode_frames(frame_list, filepath, self._video_codec, self._video_duration, self._image_to_frame)
             os_nice(0)
 
         return _read_and_cleanup_video(filepath), thumb_bio, width, height

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -258,9 +258,8 @@ class BotConfig(ConfigHelper):
 
 
 class CameraConfig(ConfigHelper):
-    """Config for the [camera] section."""
+    """Config for a [camera] or [camera <name>] section."""
 
-    _section = "camera"
     _KNOWN_ITEMS: ClassVar[list[str]] = [
         "host",
         "host_snapshot",
@@ -274,12 +273,17 @@ class CameraConfig(ConfigHelper):
         "light_control_timeout",
         "picture_quality",
         "type",
+        "enabled",
+        "use_for_status",
+        "use_for_timelapse",
     ]
 
-    def __init__(self, config: configparser.ConfigParser) -> None:
+    def __init__(self, config: configparser.ConfigParser, name: str, section: str) -> None:
         super().__init__(config)
-        self.enabled: bool = config.has_section(self._section)
+        self._section = section
+        self.name: str = name
         self.cam_type: str = self._get_str("type", default="mjpeg", allowed_values=["opencv", "ffmpeg", "mjpeg", "raw_stream"])
+        self.enabled: bool = self._get_boolean("enabled", default=True)
         self.host: str = self._get_str("host", default="")
         self.host_snapshot: str = self._get_str("host_snapshot", default="")
         self.stream_fps: int = self._get_int("fps", default=0, above=0)
@@ -295,6 +299,8 @@ class CameraConfig(ConfigHelper):
         self.video_duration: int = self._get_int("video_duration", default=5, above=0)
         self.light_timeout: int = self._get_int("light_control_timeout", default=0, min_value=0)
         self.picture_quality: str = self._get_str("picture_quality", default="high", allowed_values=["low", "high"])
+        self.use_for_timelapse: bool = self._get_boolean("use_for_timelapse", default=(name == "default"))
+        self.use_for_status: bool = self._get_boolean("use_for_status", default=(name == "default"))
 
 
 class NotifierConfig(ConfigHelper):
@@ -506,30 +512,59 @@ class ConfigWrapper:
                 config.read(path.parent / addit_conf)
 
         self._config = config
+        self.parsing_errors: str = ""
         self.secrets = SecretsConfig(config)
         self.bot_config = BotConfig(config)
-        self.camera = CameraConfig(config)
+        self.cameras: dict[str, CameraConfig] = self._parse_cameras(config)
+        # Compatibility for code paths that are still single-camera in this PR.
+        self.camera = self.default_camera or CameraConfig(config, name="default", section="camera")
         self.notifications = NotifierConfig(config)
         self.timelapse = TimelapseConfig(config)
         self.telegram_ui = TelegramUIConfig(config)
         self.status_message_content = StatusMessageContentConfig(config)
         self.unknown_fields = (
             self.bot_config.unknown_fields
-            + self.camera.unknown_fields
+            + "".join(cam.unknown_fields for cam in self.cameras.values())
             + self.notifications.unknown_fields
             + self.timelapse.unknown_fields
             + self.telegram_ui.unknown_fields
             + self.status_message_content.unknown_fields
         )
-        self.parsing_errors = (
+        self.parsing_errors += (
             self.secrets.parsing_errors
             + self.bot_config.parsing_errors
-            + self.camera.parsing_errors
+            + "".join(cam.parsing_errors for cam in self.cameras.values())
             + self.notifications.parsing_errors
             + self.timelapse.parsing_errors
             + self.telegram_ui.parsing_errors
             + self.status_message_content.parsing_errors
         )
+
+    def _parse_cameras(self, config: configparser.ConfigParser) -> dict[str, CameraConfig]:
+        cameras: dict[str, CameraConfig] = {}
+        if config.has_section("camera"):
+            cameras["default"] = CameraConfig(config, name="default", section="camera")
+        for section in config.sections():
+            # Reject [camera default] entirely — the real default is [camera].
+            if section == "camera default":
+                self.parsing_errors += "Use [camera] instead of [camera default]\n"
+                continue
+            if section.startswith("camera "):
+                name = section.split(" ", 1)[1]
+                cameras[name] = CameraConfig(config, name=name, section=section)
+        return cameras
+
+    @property
+    def default_camera(self) -> CameraConfig | None:
+        return next(iter(self.cameras.values()), None)
+
+    @property
+    def timelapse_cameras(self) -> dict[str, CameraConfig]:
+        return {name: cam for name, cam in self.cameras.items() if cam.use_for_timelapse}
+
+    @property
+    def status_cameras(self) -> dict[str, CameraConfig]:
+        return {name: cam for name, cam in self.cameras.items() if cam.use_for_status}
 
     def dump_config_to_log(self) -> None:
         config_copy = copy.deepcopy(self._config)

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -290,7 +290,7 @@ class CameraConfig(ConfigHelper):
         self.flip_vertically: bool = self._get_boolean("flip_vertically", default=False)
         self.flip_horizontally: bool = self._get_boolean("flip_horizontally", default=False)
         self.rotate: str = self._get_str("rotate", default="", allowed_values=["", "90_cw", "90_ccw", "180"])
-        self.fourcc: str = self._get_str("fourcc", default="h264", allowed_values=["h264", "mpeg4"])
+        self.video_codec: str = self._get_str("fourcc", default="h264", allowed_values=["h264", "mpeg4"])
 
         # TODO: [fixme] fix default calcs! add check max value cpu count
         # self.threads: int = self._getint( "threads", fallback=int(len(os.sched_getaffinity(0)) / 2))
@@ -516,8 +516,6 @@ class ConfigWrapper:
         self.secrets = SecretsConfig(config)
         self.bot_config = BotConfig(config)
         self.cameras: dict[str, CameraConfig] = self._parse_cameras(config)
-        # Compatibility for code paths that are still single-camera in this PR.
-        self.camera = self.default_camera or CameraConfig(config, name="default", section="camera")
         self.notifications = NotifierConfig(config)
         self.timelapse = TimelapseConfig(config)
         self.telegram_ui = TelegramUIConfig(config)

--- a/bot/main.py
+++ b/bot/main.py
@@ -50,7 +50,7 @@ from telegram.constants import ChatAction, ParseMode
 from telegram.error import BadRequest
 from telegram.ext import Application, CallbackContext, CallbackQueryHandler, CommandHandler, ContextTypes, MessageHandler, filters
 
-from camera import Camera, FFmpegCamera, MjpegCamera, OpenCVCamera, RawStreamCamera
+from camera import Camera, create_camera
 from configuration import ConfigWrapper
 from klippy import Klippy, PowerDevice, PrintState
 from notifications import Notifier
@@ -139,7 +139,7 @@ _MAX_BOT_COMMANDS: Final = 100
 
 config_wrap: ConfigWrapper
 main_pid = os.getpid()
-camera_wrap: Camera
+cameras: dict[str, Camera]
 timelapse: Timelapse
 notifier: Notifier
 klippy: Klippy
@@ -147,6 +147,31 @@ light_power_device: PowerDevice | None
 psu_power_device: PowerDevice | None
 ws_helper: WebSocketHelper
 executors_pool: ThreadPoolExecutor = ThreadPoolExecutor(2, thread_name_prefix="bot_pool")
+
+
+def default_camera() -> Camera | None:
+    return next(iter(cameras.values()), None)
+
+
+def _resolve_camera(args: list[str] | None) -> Camera | None:
+    """Resolve camera from command arguments. Returns None if selection is needed."""
+    if len(cameras) == 1:
+        return default_camera()
+    if args:
+        return cameras.get(" ".join(args))
+    return None
+
+
+async def _send_camera_selection(effective_message: Message, command: str) -> None:
+    """Send inline keyboard for camera selection."""
+    buttons = [InlineKeyboardButton(name, callback_data=f"{command}:{name}") for name in cameras]
+    keyboard = [buttons[i : i + 3] for i in range(0, len(buttons), 3)]
+    await effective_message.reply_text(
+        emoji.emojize(":camera: Select camera:", language="alias"),
+        reply_markup=InlineKeyboardMarkup(keyboard),
+        disable_notification=notifier.silent_commands,
+        do_quote=True,
+    )
 
 
 async def echo_unknown(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
@@ -179,9 +204,10 @@ async def status_no_confirm(effective_message: Message) -> None:
     else:
         text = await klippy.get_status()
         message = TelegramMessageRepr(text, parse_mode=ParseMode.HTML, silent=notifier.silent_commands, reply_markup=notifier.get_status_keyboard(state=PrintState.STANDBY))
-        if camera_wrap.enabled:
+        cam = default_camera()
+        if cam is not None:
             loop_loc = asyncio.get_running_loop()
-            with await loop_loc.run_in_executor(executors_pool, camera_wrap.take_photo) as bio:
+            with await loop_loc.run_in_executor(executors_pool, cam.take_photo) as bio:
                 if is_inline_button_press:
                     await message.update_existing(effective_message, photo=bio)
                 else:
@@ -249,49 +275,55 @@ async def get_ip(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
         await get_ip_no_confirm(update.effective_message)
 
 
-async def get_video_no_confirm(effective_message: Message) -> None:
-    if not camera_wrap.enabled:
-        await effective_message.reply_text("camera is disabled", do_quote=True)
+async def get_video_no_confirm(effective_message: Message, camera: Camera) -> None:
+    info_reply: Message = await effective_message.reply_text(
+        text="Starting video recording",
+        disable_notification=notifier.silent_commands,
+        do_quote=True,
+    )
+    await effective_message.get_bot().send_chat_action(chat_id=config_wrap.secrets.chat_id, action=ChatAction.RECORD_VIDEO)
+
+    loop_loc = asyncio.get_running_loop()
+    video_bio, thumb_bio, width, height = await loop_loc.run_in_executor(executors_pool, camera.take_video)
+    await info_reply.edit_text(text="Uploading video")
+    max_upload_file_size: int = config_wrap.bot_config.max_upload_file_size
+    if video_bio.getbuffer().nbytes > max_upload_file_size * 1024 * 1024:
+        await info_reply.edit_text(text=f"Telegram has a {max_upload_file_size}mb restriction...")
     else:
-        info_reply: Message = await effective_message.reply_text(
-            text="Starting video recording",
+        await effective_message.reply_video(
+            video=video_bio,
+            thumbnail=thumb_bio,
+            width=width,
+            height=height,
+            caption="",
+            write_timeout=120,
             disable_notification=notifier.silent_commands,
             do_quote=True,
         )
-        await effective_message.get_bot().send_chat_action(chat_id=config_wrap.secrets.chat_id, action=ChatAction.RECORD_VIDEO)
+        await effective_message.get_bot().delete_message(chat_id=config_wrap.secrets.chat_id, message_id=info_reply.message_id)
 
-        loop_loc = asyncio.get_running_loop()
-        video_bio, thumb_bio, width, height = await loop_loc.run_in_executor(executors_pool, camera_wrap.take_video)
-        await info_reply.edit_text(text="Uploading video")
-        max_upload_file_size: int = config_wrap.bot_config.max_upload_file_size
-        if video_bio.getbuffer().nbytes > max_upload_file_size * 1024 * 1024:
-            await info_reply.edit_text(text=f"Telegram has a {max_upload_file_size}mb restriction...")
-        else:
-            await effective_message.reply_video(
-                video=video_bio,
-                thumbnail=thumb_bio,
-                width=width,
-                height=height,
-                caption="",
-                write_timeout=120,
-                disable_notification=notifier.silent_commands,
-                do_quote=True,
-            )
-            await effective_message.get_bot().delete_message(chat_id=config_wrap.secrets.chat_id, message_id=info_reply.message_id)
-
-        video_bio.close()
-        thumb_bio.close()
+    video_bio.close()
+    thumb_bio.close()
 
 
-async def get_video(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
+async def get_video(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if update.effective_message is None:
         logger.warning("Undefined effective message")
         return
 
+    if not cameras:
+        await update.effective_message.reply_text("No camera is configured.", do_quote=True)
+        return
+
+    cam = _resolve_camera(context.args)
+    if cam is None:
+        await _send_camera_selection(update.effective_message, "video")
+        return
+
     if config_wrap.telegram_ui.is_present_in_require_confirmation("video") or config_wrap.telegram_ui.confirm_command():
-        await command_confirm_message(update, text="Get video?", callback_mess="video:")
+        await command_confirm_message(update, text="Get video?", callback_mess=f"video:{cam.name}")
     else:
-        await get_video_no_confirm(update.effective_message)
+        await get_video_no_confirm(update.effective_message, cam)
 
 
 def confirm_keyboard(callback_mess: str) -> InlineKeyboardMarkup:
@@ -839,6 +871,13 @@ async def button_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         await get_macros_no_confirm(update.effective_message.reply_to_message)
     elif "help:" in query.data:
         await help_command_no_confirm(update.effective_message.reply_to_message)
+    elif query.data.startswith("video:"):
+        cam_name = query.data.removeprefix("video:")
+        cam = cameras.get(cam_name)
+        if cam is None:
+            await update.effective_message.reply_text("Camera is no longer available. Use /video to choose a camera.", do_quote=True)
+        else:
+            await get_video_no_confirm(update.effective_message.reply_to_message, cam)
     elif "status:" in query.data:
         await status_no_confirm(update.effective_message.reply_to_message)
     elif "ip:" in query.data:
@@ -1148,7 +1187,7 @@ def create_keyboard() -> list[list[str]]:
         return config_wrap.telegram_ui.buttons
 
     custom_keyboard = []
-    if camera_wrap.enabled:
+    if cameras:
         custom_keyboard.append("/video")
     if psu_power_device:
         custom_keyboard.append("/power")
@@ -1419,18 +1458,12 @@ if __name__ == "__main__":
     klippy.psu_device = psu_power_device
     klippy.light_device = light_power_device
 
-    cam_type = config_wrap.camera.cam_type
-    if cam_type == "mjpeg":
-        camera_wrap = MjpegCamera(config_wrap, klippy, rotating_handler)
-    elif cam_type == "ffmpeg":
-        camera_wrap = FFmpegCamera(config_wrap, klippy, rotating_handler)
-    elif cam_type == "raw_stream":
-        camera_wrap = RawStreamCamera(config_wrap, klippy, rotating_handler)
-    else:
-        camera_wrap = OpenCVCamera(config_wrap, klippy, rotating_handler)
+    cameras = {name: cam for name, cam_config in config_wrap.cameras.items() if (cam := create_camera(cam_config, config_wrap, klippy, rotating_handler))}
     bot_updater = start_bot(config_wrap)
-    timelapse = Timelapse(config_wrap, klippy, camera_wrap, a_scheduler, bot_updater.bot, rotating_handler)
-    notifier = Notifier(config_wrap, bot_updater.bot, klippy, camera_wrap, a_scheduler, rotating_handler)
+    timelapse_camera = next((cameras[name] for name in config_wrap.timelapse_cameras if name in cameras), None)
+    status_camera = next((cameras[name] for name in config_wrap.status_cameras if name in cameras), None)
+    timelapse = Timelapse(config_wrap, klippy, timelapse_camera, a_scheduler, bot_updater.bot, rotating_handler)
+    notifier = Notifier(config_wrap, bot_updater.bot, klippy, status_camera, a_scheduler, rotating_handler)
 
     ws_helper = WebSocketHelper(config_wrap, klippy, notifier, timelapse, a_scheduler, rotating_handler)
 

--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -40,13 +40,13 @@ class Notifier:
         config: ConfigWrapper,
         bot: Bot,
         klippy: Klippy,
-        camera_wrapper: Camera,
+        camera_wrapper: Camera | None,
         scheduler: BaseScheduler,
         logging_handler: logging.Handler,
     ) -> None:
         self._bot: Bot = bot
         self._chat_id: int = config.secrets.chat_id
-        self._cam_wrap: Camera = camera_wrapper
+        self._cam_wrap: Camera | None = camera_wrapper
 
         self._sched: BaseScheduler = scheduler
         self._executors_pool: ThreadPoolExecutor = ThreadPoolExecutor(2, thread_name_prefix="notifier_pool")
@@ -191,6 +191,9 @@ class Notifier:
                 self._groups_status_messages[group] = sent_message
 
     async def _send_photo(self, message: TelegramMessageRepr, group_only: bool = False, manual: bool = False) -> None:
+        if self._cam_wrap is None:
+            msg = "_send_photo called without configured camera"
+            raise RuntimeError(msg)
         loop = asyncio.get_running_loop()
         with await loop.run_in_executor(self._executors_pool, self._cam_wrap.take_photo) as photo:
             if not group_only:
@@ -220,7 +223,7 @@ class Notifier:
         if state.is_finished:
             await asyncio.sleep(5)
         try:
-            if self._cam_wrap.enabled:
+            if self._cam_wrap is not None:
                 await self._send_photo(message, group_only=group_only, manual=manual)
             else:
                 await self._send_message(message, group_only=group_only, manual=manual)

--- a/bot/timelapse.py
+++ b/bot/timelapse.py
@@ -64,7 +64,6 @@ class Timelapse:
         self._after_lapse_gcode: str = config.timelapse.after_lapse_gcode
         self._send_finished_lapse: bool = config.timelapse.send_finished_lapse
         self._after_photo_gcode: str = config.timelapse.after_photo_gcode
-        self._fourcc: str = config.camera.fourcc
 
         self._silent_progress: bool = config.telegram_ui.silent_progress
 
@@ -436,7 +435,7 @@ class Timelapse:
 
         out = ffmpegcv.VideoWriter(
             video_filepath.as_posix(),
-            codec=self._fourcc,
+            codec=self._camera.video_codec,
             fps=lapse_fps,
         )
 

--- a/bot/timelapse.py
+++ b/bot/timelapse.py
@@ -45,12 +45,12 @@ class Timelapse:
         self,
         config: ConfigWrapper,
         klippy: Klippy,
-        camera: Camera,
+        camera: Camera | None,
         scheduler: BaseScheduler,
         bot: Bot,
         logging_handler: logging.Handler,
     ) -> None:
-        self._enabled: bool = config.timelapse.enabled and camera.enabled
+        self._enabled: bool = config.timelapse.enabled and camera is not None
         self._mode_manual: bool = config.timelapse.mode_manual
         self._height: float = config.timelapse.height
         self._interval: int = config.timelapse.interval
@@ -69,7 +69,7 @@ class Timelapse:
         self._silent_progress: bool = config.telegram_ui.silent_progress
 
         self._klippy: Klippy = klippy
-        self._camera: Camera = camera
+        self._camera: Camera | None = camera
 
         self._base_dir: Path = config.timelapse.base_dir
         self._ready_dir: Path | None = config.timelapse.ready_dir
@@ -214,6 +214,8 @@ class Timelapse:
             self._lapse_missed_frames += 1
 
     def _take_lapse_and_gcode(self, lapse_dir: Path, after_gcode: str | None) -> bool:
+        if self._camera is None:
+            return False
         result = self._camera.take_lapse_photo(lapse_dir)
         if after_gcode:
             try:
@@ -393,6 +395,8 @@ class Timelapse:
         if not printing_filename:
             msg = "Gcode file name is empty"
             raise ValueError(msg)
+        if self._camera is None:
+            raise RuntimeError("Camera is not configured")
 
         while self._camera.light_need_off:
             time.sleep(1)

--- a/tests/camera_test.py
+++ b/tests/camera_test.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
 import httpx
 
-from camera import MjpegCamera
+import camera
+from camera import MjpegCamera, create_camera
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def _make_camera(transport: httpx.MockTransport) -> MjpegCamera:
@@ -50,3 +57,20 @@ def test_fetch_raw_snapshot_rejects_jpeg2000_substring_match() -> None:
 
     bio = _make_camera(httpx.MockTransport(handler))._fetch_raw_snapshot()
     assert bio.getvalue() == b""
+
+
+def test_create_camera_skips_config_without_host() -> None:
+    cam_config = MagicMock()
+    cam_config.host = ""
+
+    assert create_camera(cam_config, MagicMock(), MagicMock(), MagicMock()) is None
+
+
+def test_create_camera_skips_opencv_when_dependency_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    cam_config = MagicMock()
+    cam_config.host = "/dev/video0"
+    cam_config.cam_type = "opencv"
+    cam_config.name = "usb"
+    monkeypatch.setattr(camera, "cv2", None)
+
+    assert create_camera(cam_config, MagicMock(), MagicMock(), MagicMock()) is None

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -103,3 +103,100 @@ def test_dump_does_not_add_redacted_for_unset_options(config_helper: ConfigWrapp
     dumped = _read_dumped_config(config_helper)
     assert not dumped.has_option("bot", "password")
     assert not dumped.has_option("bot", "api_token")
+
+
+def test_single_camera_section(config_helper: ConfigWrapper) -> None:
+    assert "default" in config_helper.cameras
+    assert config_helper.cameras["default"].host
+    assert config_helper.default_camera is not None
+    assert config_helper.default_camera.name == "default"
+
+
+def test_multi_camera_sections(tmp_path: Path) -> None:
+    conf_file = tmp_path / "multi_cam.conf"
+    conf_file.write_text("""\
+[bot]
+server: localhost
+bot_token: 123:abc
+chat_id: 123
+
+[camera]
+host: http://cam1/stream
+
+[camera bed]
+host: http://cam2/stream
+""")
+    config = ConfigWrapper(conf_file)
+    assert len(config.cameras) == 2
+    assert "default" in config.cameras
+    assert "bed" in config.cameras
+    assert config.cameras["default"].host == "http://cam1/stream"
+    assert config.cameras["bed"].host == "http://cam2/stream"
+
+
+def test_camera_default_named_section_reports_error(tmp_path: Path) -> None:
+    conf_file = tmp_path / "named_default.conf"
+    conf_file.write_text("""\
+[bot]
+server: localhost
+bot_token: 123:abc
+chat_id: 123
+
+[camera default]
+host: http://cam1/stream
+""")
+    config = ConfigWrapper(conf_file)
+    assert "Use [camera] instead of [camera default]" in config.parsing_errors
+
+
+def test_camera_default_named_section_is_ignored(tmp_path: Path) -> None:
+    """`[camera default]` reports an error and is not parsed — it must not shadow `[camera]`."""
+    conf_file = tmp_path / "named_default.conf"
+    conf_file.write_text("""\
+[bot]
+server: localhost
+bot_token: 123:abc
+chat_id: 123
+
+[camera]
+host: http://real-default/stream
+
+[camera default]
+host: http://override/stream
+""")
+    config = ConfigWrapper(conf_file)
+    assert "Use [camera] instead of [camera default]" in config.parsing_errors
+    assert "default" in config.cameras
+    assert config.cameras["default"].host == "http://real-default/stream"
+    assert len(config.cameras) == 1  # `[camera default]` did not register as a second entry
+
+
+def test_camera_default_named_section_alone_is_ignored(tmp_path: Path) -> None:
+    """Without `[camera]`, a lone `[camera default]` still can't register itself as the default."""
+    conf_file = tmp_path / "lone_default.conf"
+    conf_file.write_text("""\
+[bot]
+server: localhost
+bot_token: 123:abc
+chat_id: 123
+
+[camera default]
+host: http://override/stream
+""")
+    config = ConfigWrapper(conf_file)
+    assert "Use [camera] instead of [camera default]" in config.parsing_errors
+    assert "default" not in config.cameras
+    assert config.default_camera is None
+
+
+def test_no_camera_section(tmp_path: Path) -> None:
+    conf_file = tmp_path / "no_cam.conf"
+    conf_file.write_text("""\
+[bot]
+server: localhost
+bot_token: 123:abc
+chat_id: 123
+""")
+    config = ConfigWrapper(conf_file)
+    assert len(config.cameras) == 0
+    assert config.default_camera is None

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -110,6 +110,11 @@ def test_single_camera_section(config_helper: ConfigWrapper) -> None:
     assert config_helper.cameras["default"].host
     assert config_helper.default_camera is not None
     assert config_helper.default_camera.name == "default"
+    assert not hasattr(config_helper, "camera")
+
+
+def test_camera_fourcc_is_exposed_as_video_codec(config_helper: ConfigWrapper) -> None:
+    assert config_helper.cameras["default"].video_codec == "h264"
 
 
 def test_multi_camera_sections(tmp_path: Path) -> None:

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,4 +1,9 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import main
 from main import prepare_command
+import pytest
 
 
 def test_bot_commands_preparation() -> None:
@@ -8,3 +13,44 @@ def test_bot_commands_preparation() -> None:
     assert valid_command
     assert long_command is None
     assert invalid_symblos_command is None
+
+
+def test_resolve_camera_by_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    front = SimpleNamespace(name="front")
+    bed = SimpleNamespace(name="bed")
+    monkeypatch.setattr(main, "cameras", {"front": front, "bed": bed}, raising=False)
+
+    assert main._resolve_camera(["bed"]) is bed
+    assert main._resolve_camera(["missing"]) is None
+
+
+@pytest.mark.asyncio
+async def test_video_command_shows_camera_selection(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(main, "cameras", {"front": SimpleNamespace(name="front"), "bed": SimpleNamespace(name="bed")}, raising=False)
+    monkeypatch.setattr(main, "notifier", SimpleNamespace(silent_commands=False), raising=False)
+
+    message = MagicMock()
+    message.reply_text = AsyncMock()
+    update = SimpleNamespace(effective_message=message)
+    context = SimpleNamespace(args=[])
+
+    await main.get_video(update, context)
+
+    message.reply_text.assert_awaited_once()
+    markup = message.reply_text.await_args.kwargs["reply_markup"].to_dict()
+    buttons = [button["callback_data"] for row in markup["inline_keyboard"] for button in row]
+    assert buttons == ["video:front", "video:bed"]
+
+
+@pytest.mark.asyncio
+async def test_video_command_without_cameras_reports_missing_camera(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(main, "cameras", {}, raising=False)
+
+    message = MagicMock()
+    message.reply_text = AsyncMock()
+    update = SimpleNamespace(effective_message=message)
+    context = SimpleNamespace(args=[])
+
+    await main.get_video(update, context)
+
+    message.reply_text.assert_awaited_once_with("No camera is configured.", do_quote=True)

--- a/tests/notifications_test.py
+++ b/tests/notifications_test.py
@@ -1,5 +1,7 @@
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from notifications import Notifier
 
@@ -29,6 +31,20 @@ def make_notifier(height: float = 5.0, percent: int = 0) -> Notifier:
     klippy.printing_duration = 100.0
 
     return Notifier(config, MagicMock(), klippy, MagicMock(), MagicMock(), logging.NullHandler())
+
+
+@pytest.mark.asyncio
+async def test_notify_without_camera_sends_text_message() -> None:
+    notifier = make_notifier()
+    notifier._cam_wrap = None
+    notifier._send_message = AsyncMock()
+    notifier._send_photo = AsyncMock()
+    message = MagicMock()
+
+    await notifier._notify(message)
+
+    notifier._send_message.assert_awaited_once_with(message, group_only=False, manual=False)
+    notifier._send_photo.assert_not_awaited()
 
 
 def test_height_notification_triggers_at_threshold() -> None:

--- a/tests/timelapse_test.py
+++ b/tests/timelapse_test.py
@@ -37,7 +37,6 @@ def make_timelapse(base_dir: Path, *, cleanup: bool = True) -> Timelapse:
     config.camera.fourcc = "h264"
 
     camera = MagicMock()
-    camera.enabled = True
 
     klippy = MagicMock()
     klippy.light_device = None

--- a/tests/timelapse_test.py
+++ b/tests/timelapse_test.py
@@ -34,9 +34,9 @@ def make_timelapse(base_dir: Path, *, cleanup: bool = True) -> Timelapse:
     config.bot_config.max_upload_file_size = 50
     config.secrets.chat_id = 123
     config.telegram_ui.silent_progress = False
-    config.camera.fourcc = "h264"
 
     camera = MagicMock()
+    camera.video_codec = "h264"
 
     klippy = MagicMock()
     klippy.light_device = None


### PR DESCRIPTION
This is the first, intentionally small PR extracted from the larger `multi-camera` branch. The original branch also included status albums, notification albums, timelapse changes, and unfinished-lapse recovery, but those parts were removed from this PR and kept for follow-up PRs to make the review more manageable. This PR only adds the configuration and runtime plumbing needed to construct multiple cameras, then wires that into `/video` camera selection.

# What changes

## Multi-camera configuration

Existing single-camera configs keep working: `[camera]` is still the default camera.

Additional cameras can be configured with named sections:

```ini
[camera]
host: http://front-cam/stream
type: mjpeg

[camera bed]
host: http://bed-cam/stream
type: mjpeg
```

`ConfigWrapper` now exposes:

- `cameras`: all parsed camera configs, keyed by camera name.
- `default_camera`: the first configured camera, or `None` when no camera is configured.
- `status_cameras` / `timelapse_cameras`: filtered camera config maps. This PR still keeps status notifications and timelapse single-camera, but they now pick the first available runtime camera from the corresponding filtered list.

`[camera default]` is rejected and ignored. The default camera remains `[camera]`; a named section called `default` would otherwise be ambiguous and could shadow the real default.

Camera sections without a `host` are parsed but no runtime `Camera` object is created for them. This lets users keep disabled/incomplete camera sections in config without making startup fail.

The old internal `ConfigWrapper.camera` compatibility alias is removed. Remaining single-camera consumers use selected runtime `Camera` objects instead. The existing config key remains `fourcc`, but the code exposes it as `video_codec` on `CameraConfig` / `Camera` because timelapse assembly reads it from the selected camera.

## Camera construction

`camera.py` now has a `create_camera(...)` factory. It centralizes backend selection and skips unavailable cameras:

- `mjpeg`, `ffmpeg`, and `raw_stream` are constructed from their own camera config.
- `opencv` is skipped when OpenCV is not available.
- disabled or host-less camera configs return `None`.

This replaces the single `camera_wrap` global in `main.py` with a `cameras: dict[str, Camera]` runtime map.

Single-camera code paths are preserved by passing one selected camera into existing `Timelapse` and `Notifier` constructors. For each path, the bot picks the first configured `use_for_timelapse` / `use_for_status` camera that was successfully constructed at runtime. Those constructors now accept `Camera | None`, so a no-camera config can start cleanly and fall back to text-only notifications/status where needed.

## `/video` selection

`/video` keeps the old behavior when exactly one camera is available.

With multiple cameras:

- `/video` shows an inline camera-selection keyboard.
- `/video <name>` records from the named camera directly.
- Confirmation callbacks include the selected camera name, so the confirmation step records from the same camera the user chose.

When no camera is available, `/video` replies with `No camera is configured.` Stale camera-selection callbacks also produce a user-facing message instead of only logging.

# What this PR does not include

These pieces were present in the larger branch, but are intentionally removed from this PR and will be sent separately:

- Multi-camera `/status` albums.
- Multi-camera notifier albums during printing.
- Multi-camera timelapse capture and assembly.
- Unfinished-lapse recovery changes for multi-camera timelapse layouts.

Keeping those out makes this PR a small foundation layer rather than another all-in-one feature branch.

# Test plan

Coverage includes:

- Single `[camera]` config still registers as the default camera.
- Multiple `[camera <name>]` sections are parsed and keyed by name.
- `[camera default]` reports a parsing error and is ignored, both standalone and when `[camera]` is also present.
- Missing `[camera]` section produces no runtime default camera.
- `fourcc` is exposed internally as `video_codec`, and `ConfigWrapper.camera` is no longer present.
- Runtime camera creation skips host-less configs and skips OpenCV when the dependency is unavailable.
- `/video` shows camera-selection buttons with multiple cameras.
- `/video` without available cameras reports that no camera is configured.
- Notifications without an available camera fall back to text messages and do not call the photo path.


Implements #51