### PR TITLE
Fix bugs, add tests, and simplify WebSocket refactor

### DIFF
--- a/bot/klippy.py
+++ b/bot/klippy.py
@@ -28,23 +28,27 @@ T = TypeVar("T")
 logger = logging.getLogger(__name__)
 
 
-class PrintState(Enum):
+class PrintState(str, Enum):
     """Klipper print job states."""
 
+    # Klipper print_stats.state values
     STANDBY = "standby"
-    START = "start"
     PRINTING = "printing"
-    FINISH = "finish"
+    PAUSED = "paused"
+    COMPLETE = "complete"
     CANCELLED = "cancelled"
     ERROR = "error"
+    # Internal bot notification states
+    NOTIFY_START = "start"
+    NOTIFY_FINISH = "finish"
 
     @property
     def is_start(self) -> bool:
-        return self == PrintState.START
+        return self == PrintState.NOTIFY_START
 
     @property
     def is_finished(self) -> bool:
-        return self in (PrintState.FINISH, PrintState.CANCELLED, PrintState.ERROR)
+        return self in (PrintState.NOTIFY_FINISH, PrintState.CANCELLED, PrintState.ERROR)
 
 
 class PowerDevice:
@@ -508,9 +512,9 @@ class Klippy:
         return await self._populate_with_thumb(self._thumbnail_path, message)
 
     _STATE_TITLES: Final = {
-        PrintState.START: "Printer started printing",
+        PrintState.NOTIFY_START: "Printer started printing",
         PrintState.PRINTING: "Printing",
-        PrintState.FINISH: "Finished printing",
+        PrintState.NOTIFY_FINISH: "Finished printing",
         PrintState.CANCELLED: "Cancelled printing",
         PrintState.ERROR: "Printing was interrupted with an error",
     }
@@ -549,7 +553,7 @@ class Klippy:
             duration_prefix = "Printed for" if state.is_finished else "Printing for"
             result += f"{duration_prefix} {timedelta(seconds=round(self.printing_duration))}\n"
 
-        if state in (PrintState.START, PrintState.PRINTING):
+        if state in (PrintState.NOTIFY_START, PrintState.PRINTING):
             eta = self._get_eta()
             if "eta" in self._message_parts:
                 result += f"Estimated time left: {eta}\n"

--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -646,7 +646,6 @@ class Notifier:
 
     async def parse_notification_params(self, message: str) -> None:
         mass_parts = message.split(sep=" ")
-        mass_parts.pop(0)
         response = ""
         for part in mass_parts:
             try:

--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -426,7 +426,7 @@ class Notifier:
 
     # TODO: refactor with TelegramMessageRepr class
     async def _send_print_start_info(self) -> None:
-        message, bio = await self._klippy.get_file_info(state=PrintState.START)
+        message, bio = await self._klippy.get_file_info(state=PrintState.NOTIFY_START)
 
         if not self._group_only:
             status_message = await self._bot.send_photo(
@@ -434,7 +434,7 @@ class Notifier:
                 photo=bio,
                 caption=message,
                 parse_mode=ParseMode.HTML,
-                reply_markup=self.get_status_keyboard(state=PrintState.START),
+                reply_markup=self.get_status_keyboard(state=PrintState.NOTIFY_START),
                 disable_notification=self.silent_status,
             )
             self._status_message = status_message
@@ -447,7 +447,7 @@ class Notifier:
                 photo=bio,
                 caption=message,
                 parse_mode=ParseMode.HTML,
-                reply_markup=self.get_status_keyboard(state=PrintState.START),
+                reply_markup=self.get_status_keyboard(state=PrintState.NOTIFY_START),
                 disable_notification=self.silent_status,
             )
         bio.close()
@@ -467,7 +467,7 @@ class Notifier:
             )
 
     async def _send_print_finish(self) -> None:
-        self._schedule_notification(state=PrintState.FINISH)
+        self._schedule_notification(state=PrintState.NOTIFY_FINISH)
 
     def send_print_finish(self) -> None:
         if self._enabled:

--- a/bot/timelapse.py
+++ b/bot/timelapse.py
@@ -543,7 +543,6 @@ class Timelapse:
 
     async def parse_timelapse_params(self, message: str) -> None:
         mass_parts = message.split(sep=" ")
-        mass_parts.pop(0)
         response = ""
         for part in mass_parts:
             try:

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -283,7 +283,7 @@ class WebSocketHelper:
             return
         state = print_stats["state"]
 
-        if state == "printing":
+        if state == PrintState.PRINTING:
             self._klippy.paused = False
             if not self._klippy.printing:
                 self._klippy.printing = True
@@ -297,18 +297,18 @@ class WebSocketHelper:
                 self._notifier.send_print_start_info()
             if not self._timelapse.manual_mode:
                 self._timelapse.paused = False
-        elif state == "paused":
+        elif state == PrintState.PAUSED:
             self._klippy.paused = True
             if not self._timelapse.manual_mode:
                 self._timelapse.paused = True
-        elif state == "complete":
+        elif state == PrintState.COMPLETE:
             self._klippy.printing = False
             self._notifier.remove_notifier_timer()
             if not self._timelapse.manual_mode:
                 self._timelapse.is_running = False
                 self._timelapse.send_timelapse()
             self._notifier.send_print_finish()
-        elif state == "error":
+        elif state == PrintState.ERROR:
             self._notifier.update_status_on_abort(state=PrintState.ERROR)
             self._klippy.printing = False
             self._timelapse.is_running = False
@@ -318,12 +318,12 @@ class WebSocketHelper:
                 logs_upload=True,
                 preformat_text=print_stats.get("message"),
             )
-        elif state == "standby":
+        elif state == PrintState.STANDBY:
             self._klippy.printing = False
             self._notifier.remove_notifier_timer()
             self._timelapse.is_running = False
             self._notifier.send_printer_status_notification(f"Printer state change: {state} \n")
-        elif state == "cancelled":
+        elif state == PrintState.CANCELLED:
             self._notifier.update_status_on_abort(state=PrintState.CANCELLED)
             self._klippy.paused = False
             self._klippy.printing = False

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -100,15 +100,6 @@ class WebSocketHelper:
         "extruder": "heater",
     }
 
-    _PRINT_STATE_CONFIGS: ClassVar[dict[str, dict[str, Any]]] = {
-        "printing": {"printing": True, "paused": False, "timelapse_running": True, "timelapse_paused": False, "remove_timer": False},
-        "paused": {"printing": True, "paused": True, "timelapse_paused": True, "remove_timer": False},
-        "complete": {"printing": False, "paused": False, "timelapse_running": False, "send_finish": True, "send_timelapse": True},
-        "error": {"printing": False, "paused": False, "timelapse_running": False, "send_error": True, "abort_state": PrintState.ERROR},
-        "standby": {"printing": False, "paused": False, "timelapse_running": False, "notify_status": True},
-        "cancelled": {"printing": False, "paused": False, "timelapse_running": False, "cleanup_timelapse": True, "notify_msg": "Print cancelled", "abort_state": PrintState.CANCELLED},
-    }
-
     _NOTIFICATION_HANDLERS: ClassVar[dict[str, Callable[..., Any]]] = {
         "notify_gcode_response": lambda self, params: self.notify_gcode_response(params),
         "notify_power_changed": lambda self, params: [self.power_device_state(d) for d in params],
@@ -328,62 +319,60 @@ class WebSocketHelper:
 
         await self._update_print_stats_from_message(print_stats)
 
-        state = print_stats.get("state")
-        if not state:
+        if "state" not in print_stats:
             return
+        state = print_stats["state"]
 
-        config = self._PRINT_STATE_CONFIGS.get(state)
-        if config is None:
-            logger.error("Unknown state: %s", state)
-            return
-
-        is_new_print = not self._klippy.printing and config.get("printing", False)
-
-        self._klippy.printing = config.get("printing", False)
-        self._klippy.paused = config.get("paused", False)
-
-        if config.get("remove_timer", True):
+        if state == "printing":
+            self._klippy.paused = False
+            if not self._klippy.printing:
+                self._klippy.printing = True
+                await self._notifier.reset_notifications()
+                self._notifier.add_notifier_timer()
+                if not self._klippy.printing_filename:
+                    await self._klippy.get_status()
+                if not self._timelapse.manual_mode:
+                    self._timelapse.clean()
+                    self._timelapse.is_running = True
+                self._notifier.send_print_start_info()
+            if not self._timelapse.manual_mode:
+                self._timelapse.paused = False
+        elif state == "paused":
+            self._klippy.paused = True
+            if not self._timelapse.manual_mode:
+                self._timelapse.paused = True
+        elif state == "complete":
+            self._klippy.printing = False
             self._notifier.remove_notifier_timer()
-        elif is_new_print:
-            await self._notifier.reset_notifications()
-            self._notifier.add_notifier_timer()
-
-        # error/standby/cancelled stop timelapse unconditionally
-        if state in ("error", "standby", "cancelled"):
-            self._timelapse.is_running = False
-
-        if not self._timelapse.manual_mode:
-            self._timelapse.paused = config.get("timelapse_paused", self._timelapse.paused)
-
-            if config.get("cleanup_timelapse"):
-                self._timelapse.clean()
-            elif config.get("timelapse_running") and is_new_print:
-                self._timelapse.clean()
-                self._timelapse.is_running = True
-            elif config.get("send_timelapse"):
+            if not self._timelapse.manual_mode:
                 self._timelapse.is_running = False
                 self._timelapse.send_timelapse()
-
-        if config.get("send_finish"):
             self._notifier.send_print_finish()
-        elif config.get("send_error"):
+        elif state == "error":
+            self._notifier.update_status_on_abort(state=PrintState.ERROR)
+            self._klippy.printing = False
+            self._timelapse.is_running = False
+            self._notifier.remove_notifier_timer()
             self._notifier.send_error(
                 f"Printer state change error: {state}\n",
                 logs_upload=True,
                 preformat_text=print_stats.get("message"),
             )
-        elif config.get("notify_status"):
+        elif state == "standby":
+            self._klippy.printing = False
+            self._notifier.remove_notifier_timer()
+            self._timelapse.is_running = False
             self._notifier.send_printer_status_notification(f"Printer state change: {state} \n")
-        elif notify_msg := config.get("notify_msg"):
-            self._notifier.send_printer_status_notification(notify_msg)
-
-        if abort_state := config.get("abort_state"):
-            self._notifier.update_status_on_abort(state=abort_state)
-
-        if is_new_print:
-            if not self._klippy.printing_filename:
-                await self._klippy.get_status()
-            self._notifier.send_print_start_info()
+        elif state == "cancelled":
+            self._notifier.update_status_on_abort(state=PrintState.CANCELLED)
+            self._klippy.paused = False
+            self._klippy.printing = False
+            self._timelapse.is_running = False
+            self._notifier.remove_notifier_timer()
+            self._timelapse.clean()
+            self._notifier.send_printer_status_notification("Print cancelled")
+        elif state:
+            logger.error("Unknown state: %s", state)
 
     async def power_device_state(self, device: dict[str, Any]) -> None:
         device_name = device["device"]

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+from enum import Enum
 from http import HTTPStatus
 import logging
 import os
 import ssl
 import traceback
-from typing import TYPE_CHECKING, Any, Callable, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import aiofiles
 import anyio
@@ -51,39 +52,17 @@ _RETRYABLE_HTTP_CODES = frozenset(
 logger = logging.getLogger(__name__)
 
 
+class KlippyState(str, Enum):
+    """Klippy firmware states reported by Moonraker."""
+
+    READY = "ready"
+    ERROR = "error"
+    SHUTDOWN = "shutdown"
+    STARTUP = "startup"
+
+
 class WebSocketHelper:
     """Subscribes to Moonraker printer events and dispatches them to the scheduler."""
-
-    _TIMELAPSE_ASYNC_COMMANDS: ClassVar[dict[str, Callable[..., Any]]] = {
-        "timelapse start": lambda self: self._timelapse_start(),
-    }
-
-    _TIMELAPSE_COMMANDS: ClassVar[dict[str, Callable[..., Any]]] = {
-        "timelapse stop": lambda self: setattr(self._timelapse, "is_running", False),
-        "timelapse pause": lambda self: setattr(self._timelapse, "paused", True),
-        "timelapse resume": lambda self: setattr(self._timelapse, "paused", False),
-        "timelapse create": lambda self: self._timelapse.send_timelapse(),
-    }
-
-    _TGNOTIFY_PREFIXES: ClassVar[dict[str, Callable[..., Any]]] = {
-        "tgnotify ": lambda notifier, mess: notifier.send_notification(mess),
-        "tgnotify_photo ": lambda notifier, mess: notifier.send_notification_with_photo(mess),
-        "tgalarm ": lambda notifier, mess: notifier.send_error(mess),
-        "tgalarm_photo ": lambda notifier, mess: notifier.send_error_with_photo(mess),
-        "tgnotify_status ": lambda notifier, mess: setattr(notifier, "tgnotify_status", mess),
-    }
-
-    _TGNOTIFY_ASYNC_PREFIXES: ClassVar[dict[str, Callable[..., Any]]] = {
-        "set_timelapse_params ": lambda timelapse, mess: timelapse.parse_timelapse_params(mess),
-        "set_notify_params ": lambda notifier, mess: notifier.parse_notification_params(mess),
-        "tgcustom_keyboard ": lambda notifier, mess: notifier.send_custom_inline_keyboard(mess),
-    }
-
-    _TG_MEDIA_PREFIXES: ClassVar[dict[str, Callable[..., Any]]] = {
-        "tg_send_image": lambda notifier, mess: notifier.send_image(mess),
-        "tg_send_video": lambda notifier, mess: notifier.send_video(mess),
-        "tg_send_document": lambda notifier, mess: notifier.send_document(mess),
-    }
 
     _SENSOR_STRIP_PREFIXES: ClassVar[tuple[str, ...]] = (
         "temperature_sensor",
@@ -99,20 +78,7 @@ class WebSocketHelper:
         "fan",
     )
 
-    _NOTIFICATION_HANDLERS: ClassVar[dict[str, Callable[..., Any]]] = {
-        "notify_gcode_response": lambda self, params: self.notify_gcode_response(params),
-        "notify_power_changed": lambda self, params: [self.power_device_state(d) for d in params],
-        "notify_status_update": lambda self, params: self.notify_status_update(params),
-    }
-
-    _WS_KLIPPY_STATES: ClassVar[dict[str, str]] = {
-        "ready": "ready",
-        "error": "error",
-        "shutdown": "shutdown",
-        "startup": "startup",
-    }
-
-    _WS_KLIPPY_RECONNECT_STATES: ClassVar[frozenset[str]] = frozenset({"error", "shutdown", "startup"})
+    _KLIPPY_RECONNECT_STATES: ClassVar[frozenset[KlippyState]] = frozenset({KlippyState.ERROR, KlippyState.SHUTDOWN, KlippyState.STARTUP})
 
     _WS_RESCHEDULE_JOB_ID: ClassVar[str] = "ws_reschedule"
 
@@ -230,15 +196,16 @@ class WebSocketHelper:
 
     async def notify_gcode_response(self, message_params: list[str]) -> None:
         if self._timelapse.manual_mode:
-            for cmd, handler in self._TIMELAPSE_ASYNC_COMMANDS.items():
-                if cmd in message_params:
-                    await handler(self)
-                    break
-
-            for cmd, handler in self._TIMELAPSE_COMMANDS.items():
-                if cmd in message_params:
-                    handler(self)
-                    break
+            if "timelapse start" in message_params:
+                await self._timelapse_start()
+            elif "timelapse stop" in message_params:
+                self._timelapse.is_running = False
+            elif "timelapse pause" in message_params:
+                self._timelapse.paused = True
+            elif "timelapse resume" in message_params:
+                self._timelapse.paused = False
+            elif "timelapse create" in message_params:
+                self._timelapse.send_timelapse()
 
         if "timelapse photo_and_gcode" in message_params:
             self._timelapse.take_lapse_photo(manually=True, with_after_gcode=True)
@@ -246,26 +213,30 @@ class WebSocketHelper:
             self._timelapse.take_lapse_photo(manually=True)
 
         message = message_params[0]
+        command, _, payload = message.partition(" ")
 
-        for prefix, handler in self._TGNOTIFY_PREFIXES.items():
-            if message.startswith(prefix):
-                payload = message[len(prefix) :]
-                handler(self._notifier, payload)
-                return
-
-        for prefix, handler in self._TGNOTIFY_ASYNC_PREFIXES.items():
-            if message.startswith(prefix):
-                payload = message[len(prefix) :]
-                if prefix == "set_timelapse_params ":
-                    await handler(self._timelapse, payload)
-                else:
-                    await handler(self._notifier, payload)
-                return
-
-        for prefix, handler in self._TG_MEDIA_PREFIXES.items():
-            if message.startswith(prefix):
-                handler(self._notifier, message)
-                return
+        if command == "tgnotify":
+            self._notifier.send_notification(payload)
+        elif command == "tgnotify_photo":
+            self._notifier.send_notification_with_photo(payload)
+        elif command == "tgnotify_status":
+            self._notifier.tgnotify_status = payload
+        elif command == "tgalarm":
+            self._notifier.send_error(payload)
+        elif command == "tgalarm_photo":
+            self._notifier.send_error_with_photo(payload)
+        elif command == "set_timelapse_params":
+            await self._timelapse.parse_timelapse_params(payload)
+        elif command == "set_notify_params":
+            await self._notifier.parse_notification_params(payload)
+        elif command == "tgcustom_keyboard":
+            await self._notifier.send_custom_inline_keyboard(payload)
+        elif command == "tg_send_image":
+            self._notifier.send_image(message)
+        elif command == "tg_send_video":
+            self._notifier.send_video(message)
+        elif command == "tg_send_document":
+            self._notifier.send_document(message)
 
     def parse_sensors(self, message_parts_loc: dict[str, Any]) -> None:
         for key, value in message_parts_loc.items():
@@ -404,7 +375,7 @@ class WebSocketHelper:
     async def _handle_klippy_disconnected_state(self, klippy_state: str, state_message: str | None = None) -> None:
         await self._klippy.on_disconnected()
         self._schedule_reconnect(f"klippy state: {klippy_state}")
-        if state_message and self._klippy.state_message != state_message and klippy_state != "startup":
+        if state_message and self._klippy.state_message != state_message and klippy_state != KlippyState.STARTUP:
             self._klippy.state_message = state_message
             self._notifier.send_error(
                 f"Klippy changed state to {self._klippy.state}",
@@ -420,9 +391,9 @@ class WebSocketHelper:
     async def _handle_klippy_state_change(self, klippy_state: str, message_result: dict[str, Any]) -> None:
         self._klippy.state = klippy_state
 
-        if klippy_state == self._WS_KLIPPY_STATES["ready"]:
+        if klippy_state == KlippyState.READY:
             await self._handle_klippy_ready_state()
-        elif klippy_state in self._WS_KLIPPY_RECONNECT_STATES:
+        elif klippy_state in self._KLIPPY_RECONNECT_STATES:
             await self._handle_klippy_disconnected_state(klippy_state, message_result.get("state_message"))
         else:
             await self._handle_unknown_klippy_state(klippy_state)
@@ -472,8 +443,13 @@ class WebSocketHelper:
 
             message_params = json_message["params"]
 
-            if handler := self._NOTIFICATION_HANDLERS.get(message_method):
-                await handler(self, message_params)
+            if message_method == "notify_gcode_response":
+                await self.notify_gcode_response(message_params)
+            elif message_method == "notify_power_changed":
+                for device in message_params:
+                    await self.power_device_state(device)
+            elif message_method == "notify_status_update":
+                await self.notify_status_update(message_params)
 
     async def manage_printing(self, command: str) -> None:
         await self._send_jsonrpc(f"printer.print.{command}")

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -102,7 +102,7 @@ class WebSocketHelper:
 
     _PRINT_STATE_CONFIGS: ClassVar[dict[str, dict[str, Any]]] = {
         "printing": {"printing": True, "paused": False, "timelapse_running": True, "timelapse_paused": False, "remove_timer": False},
-        "paused": {"printing": True, "paused": True, "timelapse_running": False, "timelapse_paused": True, "remove_timer": False},
+        "paused": {"printing": True, "paused": True, "timelapse_paused": True, "remove_timer": False},
         "complete": {"printing": False, "paused": False, "timelapse_running": False, "send_finish": True, "send_timelapse": True},
         "error": {"printing": False, "paused": False, "timelapse_running": False, "send_error": True, "abort_state": PrintState.ERROR},
         "standby": {"printing": False, "paused": False, "timelapse_running": False, "notify_status": True},
@@ -213,12 +213,12 @@ class WebSocketHelper:
         self._timelapse.stop_all()
 
     async def _update_print_stats_from_message(self, print_stats: dict[str, Any]) -> None:
-        if filename := print_stats.get("filename"):
-            await self._klippy.set_printing_filename(filename)
-        if filament_used := print_stats.get("filament_used"):
-            self._klippy.filament_used = filament_used
-        if print_duration := print_stats.get("print_duration"):
-            self._klippy.printing_duration = print_duration
+        if "filename" in print_stats:
+            await self._klippy.set_printing_filename(print_stats["filename"])
+        if "filament_used" in print_stats:
+            self._klippy.filament_used = print_stats["filament_used"]
+        if "print_duration" in print_stats:
+            self._klippy.printing_duration = print_stats["print_duration"]
 
     def _update_display_status(self, status_data: dict[str, Any], schedule_notify: bool = False) -> None:
         if "message" in status_data:
@@ -348,8 +348,11 @@ class WebSocketHelper:
             await self._notifier.reset_notifications()
             self._notifier.add_notifier_timer()
 
+        # error/standby/cancelled stop timelapse unconditionally
+        if state in ("error", "standby", "cancelled"):
+            self._timelapse.is_running = False
+
         if not self._timelapse.manual_mode:
-            self._timelapse.is_running = config.get("timelapse_running", self._timelapse.is_running)
             self._timelapse.paused = config.get("timelapse_paused", self._timelapse.paused)
 
             if config.get("cleanup_timelapse"):
@@ -358,6 +361,7 @@ class WebSocketHelper:
                 self._timelapse.clean()
                 self._timelapse.is_running = True
             elif config.get("send_timelapse"):
+                self._timelapse.is_running = False
                 self._timelapse.send_timelapse()
 
         if config.get("send_finish"):

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -85,20 +85,19 @@ class WebSocketHelper:
         "tg_send_document": lambda notifier, mess: notifier.send_document(mess),
     }
 
-    _SENSOR_TYPE_MAPPING: ClassVar[dict[str, str]] = {
-        "temperature_sensor ": "temperature_sensor",
-        "temperature_fan ": "fan",
-        "controller_fan ": "fan",
-        "fan_generic ": "fan",
-        "heater_generic ": "heater",
-        "heater_fan ": "fan",
-        "heater_bed ": "heater",
-        "extruder ": "heater",
-        "fan": "fan",
-        "heater_bed": "heater",
-        "heater_generic": "heater",
-        "extruder": "heater",
-    }
+    _SENSOR_STRIP_PREFIXES: ClassVar[tuple[str, ...]] = (
+        "temperature_sensor",
+        "temperature_fan",
+        "controller_fan",
+        "fan_generic",
+        "heater_generic",
+        "heater_fan",
+    )
+    _SENSOR_KEEP_PREFIXES: ClassVar[tuple[str, ...]] = (
+        "heater_bed",
+        "extruder",
+        "fan",
+    )
 
     _NOTIFICATION_HANDLERS: ClassVar[dict[str, Callable[..., Any]]] = {
         "notify_gcode_response": lambda self, params: self.notify_gcode_response(params),
@@ -270,25 +269,15 @@ class WebSocketHelper:
 
     def parse_sensors(self, message_parts_loc: dict[str, Any]) -> None:
         for key, value in message_parts_loc.items():
-            sensor_type = None
-            sensor_name = None
-
-            for prefix, sens_type in self._SENSOR_TYPE_MAPPING.items():
-                if key == prefix:
-                    sensor_type = sens_type
-                    sensor_name = key
+            for prefix in self._SENSOR_STRIP_PREFIXES:
+                if key.startswith(prefix):
+                    self._klippy.update_sensor(key[len(prefix) :].strip(), value)
                     break
-                if prefix.endswith(" ") and key.startswith(prefix):
-                    sensor_type = sens_type
-                    sensor_name = key[len(prefix) :]
-                    break
-                if not prefix.endswith(" ") and key.startswith(prefix) and key != prefix:
-                    sensor_type = sens_type
-                    sensor_name = key
-                    break
-
-            if sensor_type and sensor_name is not None:
-                self._klippy.update_sensor(sensor_name, value)
+            else:
+                for prefix in self._SENSOR_KEEP_PREFIXES:
+                    if key.startswith(prefix):
+                        self._klippy.update_sensor(key, value)
+                        break
 
     async def notify_status_update(self, message_params: list[dict[str, Any]]) -> None:
         await self._handle_status_update(message_params[0], schedule_notify=True)

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -254,14 +254,15 @@ class WebSocketHelper:
         await self._handle_status_update(message_params[0], schedule_notify=True)
 
     async def status_response(self, status_resp: dict[str, Any]) -> None:
-        await self._handle_status_update(status_resp, schedule_notify=True)
+        await self._handle_status_update(status_resp)
 
     async def _handle_status_update(self, status_data: dict[str, Any], schedule_notify: bool = False) -> None:
         if "gcode_move" in status_data and "gcode_position" in status_data["gcode_move"]:
             position_z = status_data["gcode_move"]["gcode_position"][2]
             self._klippy.printing_height = position_z
-            self._notifier.schedule_notification(position_z=round(position_z, 2))
-            self._timelapse.take_lapse_photo(position_z)
+            if schedule_notify:
+                self._notifier.schedule_notification(position_z=round(position_z, 2))
+                self._timelapse.take_lapse_photo(position_z)
 
         if "print_stats" in status_data:
             await self.parse_print_stats(status_data)

--- a/tests/klippy_test.py
+++ b/tests/klippy_test.py
@@ -116,7 +116,7 @@ def test_start_shows_only_object_height(mock_klippy: Klippy) -> None:
     mock_klippy._printing_filename = "test.gcode"
     mock_klippy.printing_height = 15.3
     mock_klippy.file_object_height = 19.6
-    msg = mock_klippy._get_printing_file_info(state=PrintState.START)
+    msg = mock_klippy._get_printing_file_info(state=PrintState.NOTIFY_START)
     assert "print height: 19.6mm" in msg
     assert "15.3" not in msg
 
@@ -126,7 +126,7 @@ def test_finish_shows_only_object_height(mock_klippy: Klippy) -> None:
     mock_klippy._printing_filename = "test.gcode"
     mock_klippy.printing_height = 2.0
     mock_klippy.file_object_height = 19.6
-    msg = mock_klippy._get_printing_file_info(state=PrintState.FINISH)
+    msg = mock_klippy._get_printing_file_info(state=PrintState.NOTIFY_FINISH)
     assert "print height: 19.6mm" in msg
     assert "2.0" not in msg
 
@@ -155,7 +155,7 @@ def test_start_shows_only_total_filament(mock_klippy: Klippy) -> None:
     mock_klippy.filament_total = 5000.0
     mock_klippy.filament_used = 1200.0
     mock_klippy.filament_weight = 15.0
-    msg = mock_klippy._get_printing_file_info(state=PrintState.START)
+    msg = mock_klippy._get_printing_file_info(state=PrintState.NOTIFY_START)
     assert "Filament: 5.0m" in msg
     assert "1.2m" not in msg
     assert "weight: 15.0g" in msg
@@ -168,7 +168,7 @@ def test_finish_shows_only_used_filament(mock_klippy: Klippy) -> None:
     mock_klippy.filament_total = 5000.0
     mock_klippy.filament_used = 1200.0
     mock_klippy.filament_weight = 15.0
-    msg = mock_klippy._get_printing_file_info(state=PrintState.FINISH)
+    msg = mock_klippy._get_printing_file_info(state=PrintState.NOTIFY_FINISH)
     assert "Filament used: 1.2m" in msg
     assert "5.0m" not in msg
     assert "/" not in msg.split("Filament")[1]
@@ -178,7 +178,7 @@ def test_finish_shows_printed_for(mock_klippy: Klippy) -> None:
     mock_klippy._message_parts = ["progress", "print_duration"]
     mock_klippy._printing_filename = "test.gcode"
     mock_klippy.printing_duration = 1800.0
-    msg = mock_klippy._get_printing_file_info(state=PrintState.FINISH)
+    msg = mock_klippy._get_printing_file_info(state=PrintState.NOTIFY_FINISH)
     assert "Printed for" in msg
     assert "Printing for" not in msg
 
@@ -188,7 +188,7 @@ def test_finish_hides_eta(mock_klippy: Klippy) -> None:
     mock_klippy._printing_filename = "test.gcode"
     mock_klippy.file_estimated_time = 3600.0
     mock_klippy.printing_duration = 1800.0
-    msg = mock_klippy._get_printing_file_info(state=PrintState.FINISH)
+    msg = mock_klippy._get_printing_file_info(state=PrintState.NOTIFY_FINISH)
     assert "Estimated time left" not in msg
     assert "Finish at" not in msg
 
@@ -197,7 +197,7 @@ def test_start_hides_duration(mock_klippy: Klippy) -> None:
     mock_klippy._message_parts = ["progress", "print_duration"]
     mock_klippy._printing_filename = "test.gcode"
     mock_klippy.printing_duration = 1800.0
-    msg = mock_klippy._get_printing_file_info(state=PrintState.START)
+    msg = mock_klippy._get_printing_file_info(state=PrintState.NOTIFY_START)
     assert "Printing for" not in msg
 
 

--- a/tests/websocket_helper_test.py
+++ b/tests/websocket_helper_test.py
@@ -1,7 +1,9 @@
 import logging
 from unittest.mock import AsyncMock, MagicMock
 
+import orjson
 import pytest
+from websockets.protocol import State
 
 from klippy import Klippy
 from notifications import Notifier
@@ -37,7 +39,10 @@ def mock_klippy() -> MagicMock:
     klippy.get_status = AsyncMock()
     klippy.stop_all = MagicMock()
     klippy.on_disconnected = AsyncMock()
+    klippy.on_connected = AsyncMock()
     klippy.ensure_auth = AsyncMock()
+    klippy.state = ""
+    klippy.state_message = ""
     return klippy
 
 
@@ -434,3 +439,130 @@ class TestTimelapseCommands:
         await ws_helper.notify_gcode_response(["timelapse start"])
 
         ws_helper._timelapse_start.assert_called_once()
+
+
+def _ws_notification(method: str, params: list) -> bytes:
+    return orjson.dumps({"method": method, "params": params})
+
+
+def _ws_response(request_id: int, result: dict) -> bytes:
+    return orjson.dumps({"jsonrpc": "2.0", "id": request_id, "result": result})
+
+
+class TestWebsocketToMessage:
+    @pytest.mark.asyncio
+    async def test_notify_power_changed(self, ws_helper: WebSocketHelper) -> None:
+        devices = [{"device": "printer", "status": "on"}, {"device": "light", "status": "off"}]
+        msg = _ws_notification("notify_power_changed", devices)
+
+        await ws_helper.websocket_to_message(msg)
+
+        assert ws_helper._klippy.update_power_device.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_notify_gcode_response_tgnotify(self, ws_helper: WebSocketHelper) -> None:
+        msg = _ws_notification("notify_gcode_response", ["tgnotify hello world"])
+
+        await ws_helper.websocket_to_message(msg)
+
+        ws_helper._notifier.send_notification.assert_called_once_with("hello world")
+
+    @pytest.mark.asyncio
+    async def test_notify_gcode_response_set_timelapse_params(self, ws_helper: WebSocketHelper) -> None:
+        msg = _ws_notification("notify_gcode_response", ["set_timelapse_params enabled=1 height=0.5"])
+
+        await ws_helper.websocket_to_message(msg)
+
+        ws_helper._timelapse.parse_timelapse_params.assert_called_once_with("enabled=1 height=0.5")
+
+    @pytest.mark.asyncio
+    async def test_notify_gcode_response_set_notify_params(self, ws_helper: WebSocketHelper) -> None:
+        ws_helper._notifier.parse_notification_params = AsyncMock()
+        msg = _ws_notification("notify_gcode_response", ["set_notify_params percent=5"])
+
+        await ws_helper.websocket_to_message(msg)
+
+        ws_helper._notifier.parse_notification_params.assert_called_once_with("percent=5")
+
+    @pytest.mark.asyncio
+    async def test_notify_status_update_printing(self, ws_helper: WebSocketHelper) -> None:
+        msg = _ws_notification("notify_status_update", [{"print_stats": {"state": "printing", "filename": "test.gcode"}}])
+
+        await ws_helper.websocket_to_message(msg)
+
+        assert ws_helper._klippy.printing is True
+
+    @pytest.mark.asyncio
+    async def test_notify_status_update_error_stops_timelapse(self, ws_helper: WebSocketHelper) -> None:
+        ws_helper._klippy.printing = True
+        msg = _ws_notification("notify_status_update", [{"print_stats": {"state": "error"}}])
+
+        await ws_helper.websocket_to_message(msg)
+
+        assert ws_helper._klippy.printing is False
+        assert ws_helper._timelapse.is_running is False
+        ws_helper._notifier.send_error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_notify_status_update_sensors(self, ws_helper: WebSocketHelper) -> None:
+        msg = _ws_notification("notify_status_update", [{"temperature_sensor chamber": {"temperature": 45.0}}])
+
+        await ws_helper.websocket_to_message(msg)
+
+        ws_helper._klippy.update_sensor.assert_called_once_with("chamber", {"temperature": 45.0})
+
+    @pytest.mark.asyncio
+    async def test_notify_klippy_shutdown(self, ws_helper: WebSocketHelper) -> None:
+        msg = _ws_notification("notify_klippy_shutdown", [])
+
+        await ws_helper.websocket_to_message(msg)
+
+        ws_helper._klippy.stop_all.assert_called_once()
+        ws_helper._klippy.on_disconnected.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_klippy_ready_response(self, ws_helper: WebSocketHelper) -> None:
+        ws_helper._ws = MagicMock()
+        ws_helper._ws.state = State.OPEN
+        ws_helper._ws.send = AsyncMock()
+        ws_helper._pending_requests[1] = "printer.info"
+        msg = _ws_response(1, {"state": "ready"})
+
+        await ws_helper.websocket_to_message(msg)
+
+        ws_helper._klippy.on_connected.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_klippy_error_response(self, ws_helper: WebSocketHelper) -> None:
+        ws_helper._pending_requests[1] = "printer.info"
+        msg = _ws_response(1, {"state": "error", "state_message": "MCU error"})
+
+        await ws_helper.websocket_to_message(msg)
+
+        ws_helper._klippy.on_disconnected.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unknown_notification_ignored(self, ws_helper: WebSocketHelper) -> None:
+        msg = _ws_notification("notify_unknown_method", ["something"])
+
+        await ws_helper.websocket_to_message(msg)
+
+    @pytest.mark.asyncio
+    async def test_error_without_id(self, ws_helper: WebSocketHelper, caplog: pytest.LogCaptureFixture) -> None:
+        msg = orjson.dumps({"error": {"message": "something went wrong"}})
+
+        await ws_helper.websocket_to_message(msg)
+
+        assert "something went wrong" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_state_only_message_preserves_print_data(self, ws_helper: WebSocketHelper) -> None:
+        ws_helper._klippy.printing = True
+        ws_helper._klippy.filament_used = 123.4
+        ws_helper._klippy.printing_duration = 500.0
+        msg = _ws_notification("notify_status_update", [{"print_stats": {"state": "paused"}}])
+
+        await ws_helper.websocket_to_message(msg)
+
+        assert ws_helper._klippy.filament_used == 123.4
+        assert ws_helper._klippy.printing_duration == 500.0

--- a/tests/websocket_helper_test.py
+++ b/tests/websocket_helper_test.py
@@ -308,6 +308,7 @@ class TestParsePrintStats:
 
     @pytest.mark.asyncio
     async def test_paused_state(self, ws_helper: WebSocketHelper) -> None:
+        ws_helper._klippy.printing = True
         message_params = {"print_stats": {"state": "paused"}}
 
         await ws_helper.parse_print_stats(message_params)


### PR DESCRIPTION
## Summary

Found several bugs while reviewing the refactor and added integration tests that would have caught them. Also reverted some abstractions that made things worse rather than better.

## Bug fixes

- `set_timelapse_params`/`set_notify_params` drop the first parameter — the prefix is stripped by the caller, then the downstream method does `pop(0)` on what's left, eating the first real param. Fixed by removing `pop(0)` so they just accept params directly.
- `_update_print_stats_from_message` uses walrus operator `if val := dict.get(key)` which silently skips zero/empty values (e.g. `filament_used=0` at print start, `filename=""`). Replaced with `if "key" in dict` guards to handle any value including falsy ones.
- `status_response` triggers height notifications and timelapse photos on reconnect after the unification with `notify_status_update` — on initial connection these are state snapshots, not real Z moves.

## Why dispatch tables were reverted

The dispatch tables lose all type info — everything is `Callable[..., Any]`, so mypy can't check anything. The lambdas need `setattr`/`getattr` hacks for simple assignments.

`_PRINT_STATE_CONFIGS` also introduced behavioral regressions: paused state was setting `timelapse.is_running = False` (original never touched it), and error/cancelled/standby were gating `is_running = False` behind `manual_mode` (original stopped timelapse unconditionally on these). The per-state logic is too conditional for a flat config — different ordering, nested branches, some states gate behind `manual_mode` and others don't. Reverted to the original if/elif which is explicit and mypy can actually check.

For the gcode command dispatch, used `str.partition(" ")` to split command from payload, then if/elif on the exact command word. No more prefix ordering issues (`"tgnotify"` matching before `"tgnotify_photo"`), no string duplication, no lambdas.

Kept the sensor prefix tuples and klippy reconnect states — those are just data, no `Callable` types involved.

## Other changes

- `KlippyState` and `PrintState` are now `str, Enum` so comparisons with JSON strings are type-safe
- Renamed internal bot states to `NOTIFY_START`/`NOTIFY_FINISH` to make it obvious they don't come from Klipper
- Added `PAUSED` and `COMPLETE` to `PrintState` (Klipper sends these but they were missing)