### PR TITLE
Notifier cleanup and camera snapshot fix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,9 +25,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install ffmpeg
-        run: |
-          sudo apt update
-          sudo apt install ffmpeg -y
+        uses: FedericoCarboni/setup-ffmpeg@v3.1
 
       - name: Install dependencies
         run: uv sync

--- a/bot/camera.py
+++ b/bot/camera.py
@@ -511,12 +511,15 @@ class MjpegCamera(Camera):
         try:
             response = self._http.get(self._host_snapshot)
             os_nice(15)
-            if response.is_success and response.headers["Content-Type"] == "image/jpeg":
+            response.raise_for_status()
+            # Strip MIME parameters (e.g. '; charset=binary') before matching.
+            content_type = response.headers.get("Content-Type", "").split(";", 1)[0].strip().lower()
+            if content_type in ("image/jpeg", "image/jpg"):
                 bio.write(response.content)
             else:
-                response.raise_for_status()
+                logger.warning("Unexpected Content-Type from streamer snapshot: %r", content_type)
         except HTTPError:
-            logger.exception("Streamer snapshot get failed\n%s")
+            logger.exception("Streamer snapshot get failed")
         os_nice(0)
         bio.seek(0)
         return bio

--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from io import BytesIO
 import logging
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 import aiofiles
 import anyio
@@ -20,6 +20,8 @@ from klippy import Klippy, PrintState
 from telegram_helper import TelegramMessageRepr
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from apscheduler.schedulers.base import BaseScheduler  # type: ignore[import-untyped]
 
     from camera import Camera
@@ -226,89 +228,49 @@ class Notifier:
             if state.is_finished:
                 await self.reset_notifications()
 
-    # manual notification methods
+    def _schedule_job(self, func: Callable[..., object], kwargs: dict[str, Any]) -> None:
+        self._sched.add_job(
+            func,
+            kwargs=kwargs,
+            misfire_grace_time=None,
+            coalesce=False,
+            max_instances=6,
+            replace_existing=False,
+        )
+
+    def _schedule_one_shot(self, func: Callable[..., object], kwargs: dict[str, Any] | None = None) -> None:
+        self._sched.add_job(
+            func,
+            kwargs=kwargs or {},
+            misfire_grace_time=None,
+            coalesce=False,
+            max_instances=1,
+            replace_existing=True,
+        )
+
     def send_error(self, message: str, logs_upload: bool = False, preformat_text: str | None = None) -> None:
         if preformat_text:
             message += f"\n<pre>{preformat_text}</pre>"
         if logs_upload:
             message += "\nUpload logs to analyzer /logs_upload\nSend logs to chat /logs"
         tg_message = TelegramMessageRepr(text=message)
-        self._sched.add_job(
-            self._send_message,
-            kwargs={
-                "message": tg_message,
-                "manual": True,
-            },
-            misfire_grace_time=None,
-            coalesce=False,
-            max_instances=6,
-            replace_existing=False,
-        )
+        self._schedule_job(self._send_message, {"message": tg_message, "manual": True})
 
     def send_error_with_photo(self, message: str) -> None:
         tg_message = TelegramMessageRepr(text=message)
-        self._sched.add_job(
-            self._notify,
-            kwargs={
-                "message": tg_message,
-                "manual": True,
-            },
-            misfire_grace_time=None,
-            coalesce=False,
-            max_instances=6,
-            replace_existing=False,
-        )
+        self._schedule_job(self._notify, {"message": tg_message, "manual": True})
 
     def send_printer_status_notification(self, message: str) -> None:
-        tg_message = TelegramMessageRepr(
-            text=message,
-            silent=self._silent_status,
-        )
-        self._sched.add_job(
-            self._send_message,
-            kwargs={
-                "message": tg_message,
-                "manual": True,
-            },
-            misfire_grace_time=None,
-            coalesce=False,
-            max_instances=6,
-            replace_existing=False,
-        )
+        tg_message = TelegramMessageRepr(text=message, silent=self._silent_status)
+        self._schedule_job(self._send_message, {"message": tg_message, "manual": True})
 
     def send_notification(self, message: str) -> None:
-        tg_message = TelegramMessageRepr(
-            text=message,
-            silent=self._silent_commands,
-        )
-        self._sched.add_job(
-            self._send_message,
-            kwargs={
-                "message": tg_message,
-                "manual": True,
-            },
-            misfire_grace_time=None,
-            coalesce=False,
-            max_instances=6,
-            replace_existing=False,
-        )
+        tg_message = TelegramMessageRepr(text=message, silent=self._silent_commands)
+        self._schedule_job(self._send_message, {"message": tg_message, "manual": True})
 
     def send_notification_with_photo(self, message: str) -> None:
-        tg_message = TelegramMessageRepr(
-            text=message,
-            silent=self._silent_commands,
-        )
-        self._sched.add_job(
-            self._notify,
-            kwargs={
-                "message": tg_message,
-                "manual": True,
-            },
-            misfire_grace_time=None,
-            coalesce=False,
-            max_instances=6,
-            replace_existing=False,
-        )
+        tg_message = TelegramMessageRepr(text=message, silent=self._silent_commands)
+        self._schedule_job(self._notify, {"message": tg_message, "manual": True})
 
     async def reset_notifications(self) -> None:
         self._last_percent = 0
@@ -458,40 +420,21 @@ class Notifier:
 
     def send_print_start_info(self) -> None:
         if self._enabled:
-            self._sched.add_job(
-                self._send_print_start_info,
-                misfire_grace_time=None,
-                coalesce=False,
-                max_instances=1,
-                replace_existing=True,
-            )
+            self._schedule_one_shot(self._send_print_start_info)
 
     async def _send_print_finish(self) -> None:
         self._schedule_notification(state=PrintState.NOTIFY_FINISH)
 
     def send_print_finish(self) -> None:
         if self._enabled:
-            self._sched.add_job(
-                self._send_print_finish,
-                misfire_grace_time=None,
-                coalesce=False,
-                max_instances=1,
-                replace_existing=True,
-            )
+            self._schedule_one_shot(self._send_print_finish)
 
     async def _update_status_on_abort(self, state: PrintState) -> None:
         self._schedule_notification(state=state)
 
     def update_status_on_abort(self, state: PrintState) -> None:
         if self._enabled:
-            self._sched.add_job(
-                self._update_status_on_abort,
-                kwargs={"state": state},
-                misfire_grace_time=None,
-                coalesce=False,
-                max_instances=1,
-                replace_existing=True,
-            )
+            self._schedule_one_shot(self._update_status_on_abort, {"state": state})
 
     def update_status(self) -> None:
         self._schedule_notification()
@@ -548,14 +491,7 @@ class Notifier:
             await self._bot.send_message(self._chat_id, text=f"Error sending image: {ex}", disable_notification=self._silent_commands)
 
     def send_image(self, ws_message: str) -> None:
-        self._sched.add_job(
-            self._send_image,
-            kwargs={"paths": self._parse_path(ws_message), "message": self._parse_message(ws_message)},
-            misfire_grace_time=None,
-            coalesce=False,
-            max_instances=6,
-            replace_existing=False,
-        )
+        self._schedule_job(self._send_image, {"paths": self._parse_path(ws_message), "message": self._parse_message(ws_message)})
 
     async def _send_video(self, paths: list[str], message: str) -> None:
         try:
@@ -592,14 +528,7 @@ class Notifier:
             await self._bot.send_message(self._chat_id, text=f"Error sending video: {ex}", disable_notification=self._silent_commands)
 
     def send_video(self, ws_message: str) -> None:
-        self._sched.add_job(
-            self._send_video,
-            kwargs={"paths": self._parse_path(ws_message), "message": self._parse_message(ws_message)},
-            misfire_grace_time=None,
-            coalesce=False,
-            max_instances=6,
-            replace_existing=False,
-        )
+        self._schedule_job(self._send_video, {"paths": self._parse_path(ws_message), "message": self._parse_message(ws_message)})
 
     async def _send_document(self, paths: list[str], message: str) -> None:
         try:
@@ -635,14 +564,7 @@ class Notifier:
             await self._bot.send_message(self._chat_id, text=f"Error sending document: {ex}", disable_notification=self._silent_commands)
 
     def send_document(self, ws_message: str) -> None:
-        self._sched.add_job(
-            self._send_document,
-            kwargs={"paths": self._parse_path(ws_message), "message": self._parse_message(ws_message)},
-            misfire_grace_time=None,
-            coalesce=False,
-            max_instances=6,
-            replace_existing=False,
-        )
+        self._schedule_job(self._send_document, {"paths": self._parse_path(ws_message), "message": self._parse_message(ws_message)})
 
     async def parse_notification_params(self, message: str) -> None:
         mass_parts = message.split(sep=" ")

--- a/bot/notifications.py
+++ b/bot/notifications.py
@@ -8,12 +8,12 @@ from datetime import datetime
 from io import BytesIO
 import logging
 import re
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, Final
 
 import aiofiles
 import anyio
 from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup, InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo, Message
-from telegram.constants import ChatAction, ParseMode
+from telegram.constants import ChatAction
 from telegram.error import BadRequest
 
 from klippy import Klippy, PrintState
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
     from configuration import ConfigWrapper
 
 logger = logging.getLogger(__name__)
+
+_NOTIFIER_TIMER_ID: Final = "notifier_timer"
 
 
 class Notifier:
@@ -359,26 +361,25 @@ class Notifier:
 
     def add_notifier_timer(self) -> None:
         if self._interval > 0:
-            # TODO: maybe check if job exists?
             self._sched.add_job(
                 self._notify_by_time,
                 "interval",
                 seconds=self._interval,
-                id="notifier_timer",
+                id=_NOTIFIER_TIMER_ID,
                 replace_existing=True,
             )
 
     def remove_notifier_timer(self) -> None:
-        if self._sched.get_job("notifier_timer"):
-            self._sched.remove_job("notifier_timer")
+        if self._sched.get_job(_NOTIFIER_TIMER_ID):
+            self._sched.remove_job(_NOTIFIER_TIMER_ID)
 
     def _reschedule_notifier_timer(self) -> None:
-        if self._interval > 0 and self._sched.get_job("notifier_timer"):
+        if self._interval > 0 and self._sched.get_job(_NOTIFIER_TIMER_ID):
             self._sched.add_job(
                 self._notify_by_time,
                 "interval",
                 seconds=self._interval,
-                id="notifier_timer",
+                id=_NOTIFIER_TIMER_ID,
                 replace_existing=True,
             )
 
@@ -386,32 +387,23 @@ class Notifier:
         await self.reset_notifications()
         self.remove_notifier_timer()
 
-    # TODO: refactor with TelegramMessageRepr class
     async def _send_print_start_info(self) -> None:
         message, bio = await self._klippy.get_file_info(state=PrintState.NOTIFY_START)
 
+        tg_message = TelegramMessageRepr(
+            text=message,
+            silent=self.silent_status,
+            reply_markup=self.get_status_keyboard(state=PrintState.NOTIFY_START),
+        )
+
         if not self._group_only:
-            status_message = await self._bot.send_photo(
-                self._chat_id,
-                photo=bio,
-                caption=message,
-                parse_mode=ParseMode.HTML,
-                reply_markup=self.get_status_keyboard(state=PrintState.NOTIFY_START),
-                disable_notification=self.silent_status,
-            )
+            status_message = await tg_message.send(self._bot, self._chat_id, bio)
             self._status_message = status_message
 
         for group_, message_thread_id in self._notify_groups:
             bio.seek(0)
-            self._groups_status_messages[group_] = await self._bot.send_photo(
-                chat_id=group_,
-                message_thread_id=message_thread_id,
-                photo=bio,
-                caption=message,
-                parse_mode=ParseMode.HTML,
-                reply_markup=self.get_status_keyboard(state=PrintState.NOTIFY_START),
-                disable_notification=self.silent_status,
-            )
+            self._groups_status_messages[group_] = await tg_message.send(self._bot, group_, bio, message_thread_id)
+
         bio.close()
 
         if self._pin_status_single_message and self._status_message is not None:

--- a/bot/websocket_helper.py
+++ b/bot/websocket_helper.py
@@ -176,12 +176,12 @@ class WebSocketHelper:
         if "print_duration" in print_stats:
             self._klippy.printing_duration = print_stats["print_duration"]
 
-    def _update_display_status(self, status_data: dict[str, Any], schedule_notify: bool = False) -> None:
+    def _update_display_status(self, status_data: dict[str, Any], *, is_initial_sync: bool) -> None:
         if "message" in status_data:
             self._notifier.m117_status = status_data["message"]
         if "progress" in status_data:
             self._klippy.printing_progress = status_data["progress"]
-            if schedule_notify:
+            if not is_initial_sync:
                 self._notifier.schedule_notification(progress=int(status_data["progress"] * 100))
 
     def _update_vsd_progress(self, vsd_data: dict[str, Any]) -> None:
@@ -251,31 +251,58 @@ class WebSocketHelper:
                         break
 
     async def notify_status_update(self, message_params: list[dict[str, Any]]) -> None:
-        await self._handle_status_update(message_params[0], schedule_notify=True)
+        await self._handle_status_update(message_params[0], is_initial_sync=False)
 
     async def status_response(self, status_resp: dict[str, Any]) -> None:
-        await self._handle_status_update(status_resp)
+        await self._handle_status_update(status_resp, is_initial_sync=True)
 
-    async def _handle_status_update(self, status_data: dict[str, Any], schedule_notify: bool = False) -> None:
+    async def _handle_status_update(self, status_data: dict[str, Any], *, is_initial_sync: bool) -> None:
         if "gcode_move" in status_data and "gcode_position" in status_data["gcode_move"]:
             position_z = status_data["gcode_move"]["gcode_position"][2]
             self._klippy.printing_height = position_z
-            if schedule_notify:
+            if not is_initial_sync:
                 self._notifier.schedule_notification(position_z=round(position_z, 2))
                 self._timelapse.take_lapse_photo(position_z)
 
         if "print_stats" in status_data:
-            await self.parse_print_stats(status_data)
+            await self.parse_print_stats(status_data, is_initial_sync=is_initial_sync)
 
         if "display_status" in status_data:
-            self._update_display_status(status_data["display_status"], schedule_notify=schedule_notify)
+            self._update_display_status(status_data["display_status"], is_initial_sync=is_initial_sync)
 
         if "virtual_sdcard" in status_data:
             self._update_vsd_progress(status_data["virtual_sdcard"])
 
         self.parse_sensors(status_data)
 
-    async def parse_print_stats(self, message_params_loc: dict[str, Any]) -> None:
+    async def _enter_active_print(self, *, is_initial_sync: bool) -> None:
+        """Transition from not-printing to an active print (printing or paused).
+
+        Called from parse_print_stats when we see PRINTING or PAUSED while klippy.printing is
+        still False — either a genuine print-start event or an initial status_response after a
+        reconnect into an already-running print. Only the core state updates run on the initial
+        sync; notifications, lapse-frame cleanup, and reset bookkeeping are skipped so we don't
+        replay the print-start message or wipe an in-progress lapse.
+        """
+        self._klippy.printing = True
+        if not is_initial_sync:
+            await self._notifier.reset_notifications()
+        self._notifier.add_notifier_timer()
+        if not self._klippy.printing_filename:
+            await self._klippy.get_status()
+        if not self._timelapse.manual_mode:
+            if not is_initial_sync:
+                self._timelapse.clean()
+            self._timelapse.is_running = True
+        if not is_initial_sync:
+            self._notifier.send_print_start_info()
+
+    async def parse_print_stats(self, message_params_loc: dict[str, Any], *, is_initial_sync: bool) -> None:
+        """Update internal state from a print_stats payload.
+
+        Core state updates always run. Side effects are skipped on the initial sync path so a
+        reconnect mid-print doesn't replay notifications or touch an in-progress lapse.
+        """
         print_stats = message_params_loc["print_stats"]
 
         await self._update_print_stats_from_message(print_stats)
@@ -287,19 +314,14 @@ class WebSocketHelper:
         if state == PrintState.PRINTING:
             self._klippy.paused = False
             if not self._klippy.printing:
-                self._klippy.printing = True
-                await self._notifier.reset_notifications()
-                self._notifier.add_notifier_timer()
-                if not self._klippy.printing_filename:
-                    await self._klippy.get_status()
-                if not self._timelapse.manual_mode:
-                    self._timelapse.clean()
-                    self._timelapse.is_running = True
-                self._notifier.send_print_start_info()
+                await self._enter_active_print(is_initial_sync=is_initial_sync)
             if not self._timelapse.manual_mode:
                 self._timelapse.paused = False
         elif state == PrintState.PAUSED:
             self._klippy.paused = True
+            if not self._klippy.printing:
+                # Reconnect into an already-paused print: klippy.on_connected() reset printing=False.
+                await self._enter_active_print(is_initial_sync=is_initial_sync)
             if not self._timelapse.manual_mode:
                 self._timelapse.paused = True
         elif state == PrintState.COMPLETE:
@@ -307,31 +329,37 @@ class WebSocketHelper:
             self._notifier.remove_notifier_timer()
             if not self._timelapse.manual_mode:
                 self._timelapse.is_running = False
-                self._timelapse.send_timelapse()
-            self._notifier.send_print_finish()
+                if not is_initial_sync:
+                    self._timelapse.send_timelapse()
+            if not is_initial_sync:
+                self._notifier.send_print_finish()
         elif state == PrintState.ERROR:
-            self._notifier.update_status_on_abort(state=PrintState.ERROR)
             self._klippy.printing = False
             self._timelapse.is_running = False
             self._notifier.remove_notifier_timer()
-            self._notifier.send_error(
-                f"Printer state change error: {state}\n",
-                logs_upload=True,
-                preformat_text=print_stats.get("message"),
-            )
+            if not is_initial_sync:
+                self._notifier.update_status_on_abort(state=PrintState.ERROR)
+                self._notifier.send_error(
+                    f"Printer state change error: {state}\n",
+                    logs_upload=True,
+                    preformat_text=print_stats.get("message"),
+                )
         elif state == PrintState.STANDBY:
             self._klippy.printing = False
             self._notifier.remove_notifier_timer()
             self._timelapse.is_running = False
-            self._notifier.send_printer_status_notification(f"Printer state change: {state} \n")
+            if not is_initial_sync:
+                # Initial sync into STANDBY is a no-op — the printer is idle, nothing to announce.
+                self._notifier.send_printer_status_notification(f"Printer state change: {state} \n")
         elif state == PrintState.CANCELLED:
-            self._notifier.update_status_on_abort(state=PrintState.CANCELLED)
             self._klippy.paused = False
             self._klippy.printing = False
             self._timelapse.is_running = False
             self._notifier.remove_notifier_timer()
-            self._timelapse.clean()
-            self._notifier.send_printer_status_notification("Print cancelled")
+            if not is_initial_sync:
+                self._notifier.update_status_on_abort(state=PrintState.CANCELLED)
+                self._timelapse.clean()
+                self._notifier.send_printer_status_notification("Print cancelled")
         elif state:
             logger.error("Unknown state: %s", state)
 

--- a/tests/camera_test.py
+++ b/tests/camera_test.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import httpx
+
+from camera import MjpegCamera
+
+
+def _make_camera(transport: httpx.MockTransport) -> MjpegCamera:
+    cam = MjpegCamera.__new__(MjpegCamera)
+    cam._http = httpx.Client(transport=transport)
+    cam._host_snapshot = "http://cam/snapshot"
+    return cam
+
+
+def test_fetch_raw_snapshot_accepts_jpeg_with_charset_parameter() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"jpegbytes", headers={"Content-Type": "image/jpeg; charset=binary"})
+
+    bio = _make_camera(httpx.MockTransport(handler))._fetch_raw_snapshot()
+    assert bio.getvalue() == b"jpegbytes"
+
+
+def test_fetch_raw_snapshot_accepts_image_jpg_alias() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"jpegbytes", headers={"Content-Type": "image/jpg"})
+
+    bio = _make_camera(httpx.MockTransport(handler))._fetch_raw_snapshot()
+    assert bio.getvalue() == b"jpegbytes"
+
+
+def test_fetch_raw_snapshot_handles_missing_content_type() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"irrelevant")
+
+    bio = _make_camera(httpx.MockTransport(handler))._fetch_raw_snapshot()
+    assert bio.getvalue() == b""
+
+
+def test_fetch_raw_snapshot_rejects_non_jpeg_image() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"\x89PNG\r\n\x1a\n", headers={"Content-Type": "image/png"})
+
+    bio = _make_camera(httpx.MockTransport(handler))._fetch_raw_snapshot()
+    assert bio.getvalue() == b""
+
+
+def test_fetch_raw_snapshot_rejects_jpeg2000_substring_match() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"jp2bytes", headers={"Content-Type": "image/jpeg2000"})
+
+    bio = _make_camera(httpx.MockTransport(handler))._fetch_raw_snapshot()
+    assert bio.getvalue() == b""

--- a/tests/websocket_helper_test.py
+++ b/tests/websocket_helper_test.py
@@ -301,7 +301,7 @@ class TestParsePrintStats:
     async def test_printing_state(self, ws_helper: WebSocketHelper) -> None:
         message_params = {"print_stats": {"state": "printing", "filename": "test.gcode"}}
 
-        await ws_helper.parse_print_stats(message_params)
+        await ws_helper.parse_print_stats(message_params, is_initial_sync=False)
 
         assert ws_helper._klippy.printing is True
         assert ws_helper._klippy.paused is False
@@ -311,7 +311,7 @@ class TestParsePrintStats:
         ws_helper._klippy.printing = True
         message_params = {"print_stats": {"state": "paused"}}
 
-        await ws_helper.parse_print_stats(message_params)
+        await ws_helper.parse_print_stats(message_params, is_initial_sync=False)
 
         assert ws_helper._klippy.paused is True
         assert ws_helper._klippy.printing is True
@@ -320,7 +320,7 @@ class TestParsePrintStats:
     async def test_complete_state(self, ws_helper: WebSocketHelper) -> None:
         message_params = {"print_stats": {"state": "complete"}}
 
-        await ws_helper.parse_print_stats(message_params)
+        await ws_helper.parse_print_stats(message_params, is_initial_sync=False)
 
         ws_helper._notifier.send_print_finish.assert_called_once()
         ws_helper._notifier.remove_notifier_timer.assert_called_once()
@@ -329,7 +329,7 @@ class TestParsePrintStats:
     async def test_error_state(self, ws_helper: WebSocketHelper) -> None:
         message_params = {"print_stats": {"state": "error"}}
 
-        await ws_helper.parse_print_stats(message_params)
+        await ws_helper.parse_print_stats(message_params, is_initial_sync=False)
 
         ws_helper._notifier.send_error.assert_called_once()
         ws_helper._notifier.update_status_on_abort.assert_called_once()
@@ -338,7 +338,7 @@ class TestParsePrintStats:
     async def test_standby_state(self, ws_helper: WebSocketHelper) -> None:
         message_params = {"print_stats": {"state": "standby"}}
 
-        await ws_helper.parse_print_stats(message_params)
+        await ws_helper.parse_print_stats(message_params, is_initial_sync=False)
 
         ws_helper._notifier.send_printer_status_notification.assert_called_once()
 
@@ -346,7 +346,7 @@ class TestParsePrintStats:
     async def test_cancelled_state(self, ws_helper: WebSocketHelper) -> None:
         message_params = {"print_stats": {"state": "cancelled"}}
 
-        await ws_helper.parse_print_stats(message_params)
+        await ws_helper.parse_print_stats(message_params, is_initial_sync=False)
 
         ws_helper._timelapse.clean.assert_called_once()
         ws_helper._notifier.send_printer_status_notification.assert_called_once()
@@ -356,7 +356,7 @@ class TestParsePrintStats:
     async def test_unknown_state_logs_error(self, ws_helper: WebSocketHelper, caplog: pytest.LogCaptureFixture) -> None:
         message_params = {"print_stats": {"state": "unknown_state"}}
 
-        await ws_helper.parse_print_stats(message_params)
+        await ws_helper.parse_print_stats(message_params, is_initial_sync=False)
 
         assert "Unknown state: unknown_state" in caplog.text
 
@@ -364,9 +364,95 @@ class TestParsePrintStats:
     async def test_empty_state_returns_early(self, ws_helper: WebSocketHelper) -> None:
         message_params = {"print_stats": {}}
 
-        await ws_helper.parse_print_stats(message_params)
+        await ws_helper.parse_print_stats(message_params, is_initial_sync=False)
 
         assert ws_helper._klippy.printing is False
+
+
+class TestStatusResponse:
+    """Initial websocket status_response path — state is restored, notifications are suppressed."""
+
+    @pytest.mark.asyncio
+    async def test_standby_does_not_notify(self, ws_helper: WebSocketHelper) -> None:
+        await ws_helper.status_response({"print_stats": {"state": "standby"}})
+
+        ws_helper._notifier.send_printer_status_notification.assert_not_called()
+        assert ws_helper._klippy.printing is False
+        ws_helper._notifier.remove_notifier_timer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_printing_restores_state_and_does_not_notify(self, ws_helper: WebSocketHelper) -> None:
+        await ws_helper.status_response({"print_stats": {"state": "printing", "filename": "test.gcode"}})
+
+        assert ws_helper._klippy.printing is True
+        assert ws_helper._klippy.paused is False
+        assert ws_helper._timelapse.is_running is True
+        ws_helper._notifier.add_notifier_timer.assert_called_once()
+        ws_helper._notifier.send_print_start_info.assert_not_called()
+        ws_helper._notifier.reset_notifications.assert_not_called()
+        ws_helper._timelapse.clean.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_printing_refreshes_filename_when_missing(self, ws_helper: WebSocketHelper) -> None:
+        ws_helper._klippy.printing_filename = ""
+
+        await ws_helper.status_response({"print_stats": {"state": "printing"}})
+
+        ws_helper._klippy.get_status.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_paused_restores_state_and_does_not_notify(self, ws_helper: WebSocketHelper) -> None:
+        # Reconnect baseline — klippy.on_connected() resets printing=False, paused=False.
+        # The initial status_response must restore the full active-print state, not just the paused flag.
+        await ws_helper.status_response({"print_stats": {"state": "paused"}})
+
+        assert ws_helper._klippy.printing is True
+        assert ws_helper._klippy.paused is True
+        assert ws_helper._timelapse.is_running is True
+        assert ws_helper._timelapse.paused is True
+        ws_helper._notifier.add_notifier_timer.assert_called_once()
+        ws_helper._notifier.send_printer_status_notification.assert_not_called()
+        ws_helper._notifier.send_print_start_info.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_paused_refreshes_filename_when_missing(self, ws_helper: WebSocketHelper) -> None:
+        ws_helper._klippy.printing_filename = ""
+
+        await ws_helper.status_response({"print_stats": {"state": "paused"}})
+
+        ws_helper._klippy.get_status.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_complete_does_not_notify_or_upload_timelapse(self, ws_helper: WebSocketHelper) -> None:
+        await ws_helper.status_response({"print_stats": {"state": "complete"}})
+
+        assert ws_helper._klippy.printing is False
+        assert ws_helper._timelapse.is_running is False
+        ws_helper._notifier.remove_notifier_timer.assert_called_once()
+        ws_helper._notifier.send_print_finish.assert_not_called()
+        ws_helper._timelapse.send_timelapse.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_error_does_not_notify(self, ws_helper: WebSocketHelper) -> None:
+        await ws_helper.status_response({"print_stats": {"state": "error"}})
+
+        assert ws_helper._klippy.printing is False
+        assert ws_helper._timelapse.is_running is False
+        ws_helper._notifier.remove_notifier_timer.assert_called_once()
+        ws_helper._notifier.send_error.assert_not_called()
+        ws_helper._notifier.update_status_on_abort.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_does_not_notify_or_clean_lapse_dir(self, ws_helper: WebSocketHelper) -> None:
+        await ws_helper.status_response({"print_stats": {"state": "cancelled"}})
+
+        assert ws_helper._klippy.printing is False
+        assert ws_helper._klippy.paused is False
+        assert ws_helper._timelapse.is_running is False
+        ws_helper._notifier.remove_notifier_timer.assert_called_once()
+        ws_helper._notifier.send_printer_status_notification.assert_not_called()
+        ws_helper._notifier.update_status_on_abort.assert_not_called()
+        ws_helper._timelapse.clean.assert_not_called()
 
 
 class TestNotifyStatusUpdate:


### PR DESCRIPTION
A few independent fixes and refactors extracted from the multi-camera PR so they can land on their own.

- **Fix regression from #435: reconnect no longer spams a "standby" notification.** The WebSocketHelper refactor routed the initial `status_response` through `_handle_status_update` with `schedule_notify=False`, but `parse_print_stats` was called unconditionally and ignored the flag. Every reconnect fired a state-change notification.
- **Keep reconnect state restoration in the same method as live updates.** `parse_print_stats` now takes `is_initial_sync` so live and initial-sync paths share one implementation. Mid-print reconnect restores `klippy.printing`, the notifier timer, timelapse running state, and refreshes the filename, but skips the "print started" message and `timelapse.clean()` so it doesn't replay the start notification or wipe an in-progress lapse. Reconnecting into a paused print goes through the same path, so it recovers the full state instead of only setting `paused`. Terminal `print_stats` states are also non-replaying on initial sync: `STANDBY`, `COMPLETE`, `ERROR`, and `CANCELLED` update internal state without resending finish/error/cancel notifications, re-uploading timelapses, or cleaning lapse directories. Klippy-level error and shutdown notifications are unchanged and still come from the separate Klippy state path.
- **Fix snapshot Content-Type handling.** `_fetch_raw_snapshot` crashed with a `KeyError` when a response omitted `Content-Type`, and the strict equality against `image/jpeg` rejected valid responses that included MIME parameters (e.g. ustreamer's `image/jpeg; charset=binary`) or used the `image/jpg` alias — silently serving the nosignal placeholder. Both `mjpeg` and `raw_stream` cameras are affected. The fix continues to reject non-jpeg image types on purpose: `take_lapse_photo` writes bytes verbatim to a `.jpeg` file, so a PNG would corrupt the timelapse.
- **Minor notifier cleanup.** Extract `_schedule_job` / `_schedule_one_shot` helpers from nine duplicated scheduler call sites, and route `_send_print_start_info` through `TelegramMessageRepr` instead of two hand-synced `bot.send_photo` calls.
- **Install ffmpeg via `FedericoCarboni/setup-ffmpeg` in CI.** `sudo apt install ffmpeg -y` sometimes hangs on GitHub runners. The action downloads a prebuilt static binary with caching across runs.

# Test plan

- 8 new `TestStatusResponse` cases cover every print state on the initial-sync path, with the paused-after-reconnect case starting from the real `on_connected()` baseline.
- 5 new `MjpegCamera._fetch_raw_snapshot` cases lock the Content-Type handling in (accepts `charset=binary` and `image/jpg`, rejects missing header, rejects `image/png`, rejects `image/jpeg2000` substring match).
- `uv run pytest tests/`
- Manual: reconnect the websocket — no spurious standby notification.