### PR TITLE
Detect unfinished lapses in gcode subfolders

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -1246,7 +1246,7 @@ async def greeting_message(bot: telegram.Bot) -> None:
         else:
             mess += "Printer online on " + get_local_ip()
             if config_wrap.configuration_errors:
-                mess += await klippy.get_versions_info(bot_only=True) + config_wrap.configuration_errors
+                mess += "\n" + await klippy.get_versions_info(bot_only=True) + config_wrap.configuration_errors
 
         use_keyboard = config_wrap.telegram_ui.send_reply_keyboard
         await bot.send_message(

--- a/bot/timelapse.py
+++ b/bot/timelapse.py
@@ -10,6 +10,7 @@ import logging
 import math
 import os
 from pathlib import Path
+import shutil
 import time
 from typing import TYPE_CHECKING, Any, Final
 
@@ -485,17 +486,14 @@ class Timelapse:
         return video_bytes, res_thumb_bytes, width, height, str(video_filepath)
 
     def _cleanup_lapse(self, lapse_filename: str, *, force: bool = False) -> None:
-        lapse_dir = self._base_dir / lapse_filename
         if self._cleanup or force:
-            for filename in lapse_dir.iterdir():
-                filename.unlink()
-            lapse_dir.rmdir()
+            shutil.rmtree(self._base_dir / lapse_filename)
 
-    # TODO: check if lapse was in subfolder (alike gcode folders)
     # TODO: check for 64 symbols length in lapse names
     def detect_unfinished_lapses(self) -> list[str]:
         # TODO: detect unstarted timelapse builds? folder with pics and no mp4 files
-        return [el.parent.name for el in self._base_dir.rglob("*.lock")]
+        # Skip stray root-level lock files: their relative name is empty and cleanup would target base_dir.
+        return ["/".join(parts) for lock_file in self._base_dir.rglob("*.lock") if (parts := lock_file.relative_to(self._base_dir).parts[:-1])]
 
     def cleanup_unfinished_lapses(self) -> None:
         for lapse_name in self.detect_unfinished_lapses():

--- a/tests/timelapse_test.py
+++ b/tests/timelapse_test.py
@@ -70,6 +70,35 @@ def test_cleanup_unfinished_lapses(tmp_path: Path) -> None:
     assert not any(tmp_path.iterdir())
 
 
+def test_detect_unfinished_lapses_in_nested_folder(tmp_path: Path) -> None:
+    lapse_name = "queued/parts/cube_2025-02-24_12-30"
+    lapse_path = tmp_path / lapse_name
+    lapse_path.mkdir(parents=True, exist_ok=True)
+    (lapse_path / "lapse.lock").touch()
+    tl = make_timelapse(tmp_path)
+    assert tl.detect_unfinished_lapses() == [lapse_name]
+
+
+def test_cleanup_unfinished_lapses_in_nested_folder(tmp_path: Path) -> None:
+    lapse_path = tmp_path / "queued" / "parts" / "cube_2025-02-24_12-30"
+    lapse_path.mkdir(parents=True, exist_ok=True)
+    (lapse_path / "lapse.lock").touch()
+    tl = make_timelapse(tmp_path)
+    tl.cleanup_unfinished_lapses()
+    assert not any(tmp_path.rglob("*.lock"))
+
+
+def test_stray_root_lock_is_ignored(tmp_path: Path) -> None:
+    (tmp_path / "lapse.lock").touch()
+    (tmp_path / "real_lapse").mkdir()
+    (tmp_path / "real_lapse" / "lapse.lock").touch()
+    tl = make_timelapse(tmp_path)
+    assert tl.detect_unfinished_lapses() == ["real_lapse"]
+    tl.cleanup_unfinished_lapses()
+    assert tmp_path.exists()
+    assert (tmp_path / "lapse.lock").exists()
+
+
 @pytest.mark.asyncio
 async def test_save_and_restore_state(tmp_path: Path) -> None:
     tl = make_timelapse(tmp_path)


### PR DESCRIPTION
Two independent fixes extracted from the multi-camera branch so they can land on their own.

- **Detect and clean up unfinished lapses for gcode in subfolders.** Closes the `# TODO: check if lapse was in subfolder` in `detect_unfinished_lapses`.
    - `detect_unfinished_lapses` returned `el.parent.name`, so a lapse nested in subfolders (e.g. `<base>/queued/parts/model_<ts>/lapse.lock`) was reported as just `model_<ts>`, and `_cleanup_lapse` then tried to delete a path that didn't exist — the lapse silently leaked.
    - Now returns the full relative lapse path and cleans it up with `shutil.rmtree`, so nested lapse directories are handled correctly.
    - Stray root-level `lapse.lock` files are filtered out just in case, their empty relative name would otherwise make cleanup target the timelapse base directory itself.
- **Fix missing newline before version info in the greeting message.** When `configuration_errors` was non-empty the startup greeting produced `...online on 192.168.1.10Bot version: ...`.