### PR TITLE
fix(camera): add optional pix_fmt for hardware encoders

### DIFF
--- a/bot/camera.py
+++ b/bot/camera.py
@@ -402,13 +402,13 @@ class Camera:
 
             logger.debug("res fps - %s", res_fps)
 
-            writer_kwargs = {"pix_fmt": self._pix_fmt} if self._pix_fmt else {}
             out = ffmpegcv.VideoWriter(
                 filepath,
                 codec=self._fourcc,
                 fps=res_fps,
-                **writer_kwargs,
             )
+            if self._pix_fmt:
+                out.target_pix_fmt = self._pix_fmt
 
             for el in frame_list:
                 loc_loc = pickle.loads(el)
@@ -534,13 +534,13 @@ class Camera:
             lapse_fps = self._target_fps
 
         with self._camera_lock:
-            writer_kwargs = {"pix_fmt": self._pix_fmt} if self._pix_fmt else {}
             out = ffmpegcv.VideoWriter(
                 video_filepath,
                 codec=self._fourcc,
                 fps=lapse_fps,
-                **writer_kwargs,
             )
+            if self._pix_fmt:
+                out.target_pix_fmt = self._pix_fmt
 
             asyncio.run_coroutine_threadsafe(info_mess.edit_text(text="Images recoding"), loop).result()
             last_update_time = time.time()
@@ -771,13 +771,13 @@ class MjpegCamera(Camera):
 
             logger.debug("res fps - %s", res_fps)
 
-            writer_kwargs = {"pix_fmt": self._pix_fmt} if self._pix_fmt else {}
             out = ffmpegcv.VideoWriter(
                 filepath,
                 codec=self._fourcc,
                 fps=res_fps,
-                **writer_kwargs,
             )
+            if self._pix_fmt:
+                out.target_pix_fmt = self._pix_fmt
 
             for el in frame_list:
                 loc_loc = pickle.loads(el)

--- a/bot/camera.py
+++ b/bot/camera.py
@@ -89,6 +89,7 @@ class Camera:
         self._flip_vertically: bool = config.camera.flip_vertically
         self._flip_horizontally: bool = config.camera.flip_horizontally
         self._fourcc: str = config.camera.fourcc
+        self._pix_fmt: str = config.camera.pix_fmt
         self._video_duration: int = config.camera.video_duration
         self._video_buffer_size: int = config.camera.video_buffer_size
         self._stream_fps: int = config.camera.stream_fps
@@ -401,10 +402,12 @@ class Camera:
 
             logger.debug("res fps - %s", res_fps)
 
+            writer_kwargs = {"pix_fmt": self._pix_fmt} if self._pix_fmt else {}
             out = ffmpegcv.VideoWriter(
                 filepath,
                 codec=self._fourcc,
                 fps=res_fps,
+                **writer_kwargs,
             )
 
             for el in frame_list:
@@ -531,10 +534,12 @@ class Camera:
             lapse_fps = self._target_fps
 
         with self._camera_lock:
+            writer_kwargs = {"pix_fmt": self._pix_fmt} if self._pix_fmt else {}
             out = ffmpegcv.VideoWriter(
                 video_filepath,
                 codec=self._fourcc,
                 fps=lapse_fps,
+                **writer_kwargs,
             )
 
             asyncio.run_coroutine_threadsafe(info_mess.edit_text(text="Images recoding"), loop).result()
@@ -766,10 +771,12 @@ class MjpegCamera(Camera):
 
             logger.debug("res fps - %s", res_fps)
 
+            writer_kwargs = {"pix_fmt": self._pix_fmt} if self._pix_fmt else {}
             out = ffmpegcv.VideoWriter(
                 filepath,
                 codec=self._fourcc,
                 fps=res_fps,
+                **writer_kwargs,
             )
 
             for el in frame_list:

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -274,7 +274,7 @@ class CameraConfig(ConfigHelper):
         self.flip_vertically: bool = self._get_boolean("flip_vertically", default=False)
         self.flip_horizontally: bool = self._get_boolean("flip_horizontally", default=False)
         self.rotate: str = self._get_str("rotate", default="", allowed_values=["", "90_cw", "90_ccw", "180"])
-        self.fourcc: str = self._get_str("fourcc", default="h264", allowed_values=["h264", "mpeg4"])
+        self.fourcc: str = self._get_str("fourcc", default="h264", allowed_values=["h264", "mpeg4", "h264_rkmpp"])
         self.pix_fmt: str = self._get_str("pix_fmt", default="")
 
         # self.threads: int = self._getint( "threads", fallback=int(len(os.sched_getaffinity(0)) / 2)) #Fixme:

--- a/bot/configuration.py
+++ b/bot/configuration.py
@@ -255,6 +255,7 @@ class CameraConfig(ConfigHelper):
         "flip_horizontally",
         "rotate",
         "fourcc",
+        "pix_fmt",
         "video_duration",
         "video_buffer_size",
         "fps",
@@ -274,6 +275,7 @@ class CameraConfig(ConfigHelper):
         self.flip_horizontally: bool = self._get_boolean("flip_horizontally", default=False)
         self.rotate: str = self._get_str("rotate", default="", allowed_values=["", "90_cw", "90_ccw", "180"])
         self.fourcc: str = self._get_str("fourcc", default="h264", allowed_values=["h264", "mpeg4"])
+        self.pix_fmt: str = self._get_str("pix_fmt", default="")
 
         # self.threads: int = self._getint( "threads", fallback=int(len(os.sched_getaffinity(0)) / 2)) #Fixme:
         self.threads: int = self._get_int("threads", default=2, min_value=0)  # Fixme: fix default calcs! add check max value cpu count

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -60,3 +60,13 @@ def test_camera_pix_fmt_accepts_value(tmp_path):
     wrapper = ConfigWrapper(cfg.as_posix())
     assert wrapper.configuration_errors == ""
     assert wrapper.camera.pix_fmt == "nv12"
+
+
+def test_camera_fourcc_accepts_rkmpp(tmp_path):
+    cfg = tmp_path / "telegram.conf"
+    cfg.write_text(
+        "[bot]\nbot_token: x\nchat_id: 1\n[camera]\nhost: http://localhost:8080/?action=stream\ntype: mjpeg\nfourcc: h264_rkmpp\n"
+    )
+    wrapper = ConfigWrapper(cfg.as_posix())
+    assert wrapper.configuration_errors == ""
+    assert wrapper.camera.fourcc == "h264_rkmpp"

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -46,3 +46,17 @@ def test_config_has_no_errors(config_helper):
 
 def test_config_bot_is_valid(config_helper):
     assert config_helper.secrets.chat_id == 16612341234 and config_helper.secrets.token == "23423423334:sdfgsdfg-dfgdfgsdfg"
+
+
+def test_camera_pix_fmt_defaults_to_empty(config_helper):
+    assert config_helper.camera.pix_fmt == ""
+
+
+def test_camera_pix_fmt_accepts_value(tmp_path):
+    cfg = tmp_path / "telegram.conf"
+    cfg.write_text(
+        "[bot]\nbot_token: x\nchat_id: 1\n[camera]\nhost: http://localhost:8080/?action=stream\ntype: mjpeg\npix_fmt: nv12\n"
+    )
+    wrapper = ConfigWrapper(cfg.as_posix())
+    assert wrapper.configuration_errors == ""
+    assert wrapper.camera.pix_fmt == "nv12"


### PR DESCRIPTION
Closes #440.

Adds an optional `pix_fmt` parameter to `[camera]`. When set, it is forwarded to `ffmpegcv.VideoWriter` in all three timelapse render paths. Empty default keeps the previous behavior.

Rockchip h264_rkmpp encoders require `nv12`; the default YU12 from ffmpegcv triggers `BrokenPipeError` from the rkisp driver. Tested locally via the unit tests for the new config field; live timelapse path runs on the same kwargs forwarding pattern already used for codec/fps.